### PR TITLE
Make `Literal::Maybe` subclasses comparable. 

### DIFF
--- a/lib/literal/nothing_class.rb
+++ b/lib/literal/nothing_class.rb
@@ -46,4 +46,14 @@ class Literal::NothingClass < Literal::Maybe
 	def deconstruct_keys(_)
 		{}
 	end
+
+	def <=>(other)
+		return unless Literal::NothingClass === other
+
+		0
+	end
+
+	def eql?(other)
+		Literal::NothingClass === other
+	end
 end

--- a/lib/literal/nothing_class.rb
+++ b/lib/literal/nothing_class.rb
@@ -47,13 +47,7 @@ class Literal::NothingClass < Literal::Maybe
 		{}
 	end
 
-	def <=>(other)
-		return unless Literal::NothingClass === other
-
-		0
-	end
-
 	def eql?(other)
-		Literal::NothingClass === other
+		Literal::Nothing == other
 	end
 end

--- a/lib/literal/some.rb
+++ b/lib/literal/some.rb
@@ -85,4 +85,16 @@ class Literal::Some < Literal::Maybe
 	def deconstruct_keys(_)
 		{ value: @value }
 	end
+
+	def <=>(other)
+		return unless Literal::Some === other
+
+		@value <=> other.value
+	end
+
+	def eql?(other)
+		return false unless Literal::Some === other
+
+		@value.eql?(other.value)
+	end
 end

--- a/lib/literal/some.rb
+++ b/lib/literal/some.rb
@@ -86,10 +86,10 @@ class Literal::Some < Literal::Maybe
 		{ value: @value }
 	end
 
-	def <=>(other)
-		return unless Literal::Some === other
+	def ==(other)
+		return false unless Literal::Some === other
 
-		@value <=> other.value
+		@value == other.value
 	end
 
 	def eql?(other)

--- a/test/literal/nothing.test.rb
+++ b/test/literal/nothing.test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+include Literal::Monads
+
+let def nothing = Literal::Nothing
+
+test "#inspect" do
+	expect(nothing.inspect) == "Literal::Nothing"
+end
+
+test "#empty?" do
+	expect(nothing).to_be :empty?
+end
+
+test "#nothing?" do
+	expect(nothing).to_be :nothing?
+end
+
+test "#something?" do
+	expect(nothing).not_to_be :something?
+end
+
+test "#value_or" do
+	expect(nothing.value_or { 42 }) == 42
+end
+
+test "#fmap" do
+	expect(nothing.fmap { |value| value * 2 }) == nothing
+end
+
+test "#map" do
+	expect(nothing.map { |value| value * 2 }) == nothing
+end
+
+test "#bind" do
+	expect(nothing.bind { |value| value * 2 }) == nothing
+end
+
+test "#then" do
+	expect(nothing.then { |value| value * 2 }) == nothing
+end
+
+test "#filter" do
+	expect(nothing.filter(&:even?)) == nothing
+end
+
+test "#===" do
+	assert Literal::Nothing === nothing
+	refute Literal::Nothing === Literal::Some(Integer).new(1)
+end
+
+test "#deconstruct" do
+	expect(nothing.deconstruct) == []
+end
+
+test "#deconstruct_keys" do
+	expect(nothing.deconstruct_keys(nil)) == {}
+end
+
+test "#eql?" do
+	assert nothing.eql?(nothing)
+	refute nothing.eql?(Literal::Some(Integer).new(1))
+end
+
+test "#==" do
+	assert nothing == Literal::Nothing
+	refute nothing == Literal::Some(Integer).new(1)
+end
+
+test "#!=" do
+	assert nothing != Literal::Some(Integer).new(1)
+	refute nothing != Literal::Nothing
+end
+
+test "#<=>" do
+	expect(nothing <=> Literal::Nothing) == 0
+	expect(nothing <=> Literal::Some(Integer).new(1)) == nil
+end
+
+# Test for Comparable
+
+test "#between?" do
+	assert nothing.between?(Literal::Nothing, Literal::Nothing)
+	some = Literal::Some(Integer)
+	expect { nothing.between?(some.new(0), some.new(1)) }.to_raise ArgumentError
+end
+
+test "#<" do
+	refute nothing < Literal::Nothing
+end
+
+test "#<=" do
+	assert nothing <= Literal::Nothing
+end
+
+test "#>" do
+	refute nothing > Literal::Nothing
+end
+
+test "#>=" do
+	assert nothing >= Literal::Nothing
+end
+
+test "#clamp" do
+	expect(nothing.clamp(Literal::Nothing, Literal::Nothing)) == Literal::Nothing
+	expect { nothing.clamp(Literal::Nothing, Literal::Some(Integer).new(1)) }.to_raise ArgumentError
+end

--- a/test/literal/nothing.test.rb
+++ b/test/literal/nothing.test.rb
@@ -71,37 +71,3 @@ test "#!=" do
 	assert nothing != Literal::Some(Integer).new(1)
 	refute nothing != Literal::Nothing
 end
-
-test "#<=>" do
-	expect(nothing <=> Literal::Nothing) == 0
-	expect(nothing <=> Literal::Some(Integer).new(1)) == nil
-end
-
-# Test for Comparable
-
-test "#between?" do
-	assert nothing.between?(Literal::Nothing, Literal::Nothing)
-	some = Literal::Some(Integer)
-	expect { nothing.between?(some.new(0), some.new(1)) }.to_raise ArgumentError
-end
-
-test "#<" do
-	refute nothing < Literal::Nothing
-end
-
-test "#<=" do
-	assert nothing <= Literal::Nothing
-end
-
-test "#>" do
-	refute nothing > Literal::Nothing
-end
-
-test "#>=" do
-	assert nothing >= Literal::Nothing
-end
-
-test "#clamp" do
-	expect(nothing.clamp(Literal::Nothing, Literal::Nothing)) == Literal::Nothing
-	expect { nothing.clamp(Literal::Nothing, Literal::Some(Integer).new(1)) }.to_raise ArgumentError
-end

--- a/test/literal/some.test.rb
+++ b/test/literal/some.test.rb
@@ -84,45 +84,4 @@ describe "Some(Integer)" do
 		assert some_val_1 != 1
 		assert some_val_1 != Literal::Nothing
 	end
-
-	test "#<=>" do
-		expect(some_val_1 <=> some_int_monad.new(1)) == 0
-		expect(some_val_1 <=> some_int_monad.new(2)) == -1
-		expect(some_val_1 <=> some_int_monad.new(0)) == 1
-		expect(some_val_1 <=> 1) == nil
-		expect(some_val_1 <=> Literal::Nothing) == nil
-	end
-
-	# Test for Comparable
-
-	test "#between?" do
-		assert some_val_1.between?(some_int_monad.new(0), some_int_monad.new(1))
-		refute some_val_1.between?(some_val_2, some_int_monad.new(3))
-		expect { some_val_1.between?(some_val_1, Literal::Nothing) }.to_raise ArgumentError
-	end
-
-	test "#<" do
-		assert some_val_1 < some_int_monad.new(2)
-		refute some_val_1 < some_int_monad.new(1)
-	end
-
-	test "#<=" do
-		assert some_val_1 <= some_int_monad.new(1)
-		refute some_val_1 <= some_int_monad.new(0)
-	end
-
-	test "#>" do
-		assert some_val_1 > some_int_monad.new(0)
-		refute some_val_1 > some_int_monad.new(1)
-	end
-
-	test "#>=" do
-		assert some_val_1 >= some_int_monad.new(1)
-		refute some_val_1 >= some_val_2
-	end
-
-	test "#clamp" do
-		expect(some_val_1.clamp(some_int_monad.new(0), some_int_monad.new(1))) == some_val_1
-		expect(some_val_1.clamp(some_val_2, some_int_monad.new(3))) == some_val_2
-	end
 end

--- a/test/literal/some.test.rb
+++ b/test/literal/some.test.rb
@@ -65,4 +65,64 @@ describe "Some(Integer)" do
 	test "#deconstruct_keys" do
 		expect(some_val_1.deconstruct_keys(nil)) == { value: 1 }
 	end
+
+	test "#eql?" do
+		assert some_val_1.eql?(some_int_monad.new(1))
+		refute some_val_1.eql?(some_int_monad.new(2))
+	end
+
+	test "#==" do
+		assert some_val_1 == some_int_monad.new(1)
+		refute some_val_1 == some_int_monad.new(2)
+		refute some_val_1 == 1
+		refute some_val_1 == Literal::Nothing
+	end
+
+	test "#!=" do
+		refute some_val_1 != some_int_monad.new(1)
+		assert some_val_1 != some_int_monad.new(2)
+		assert some_val_1 != 1
+		assert some_val_1 != Literal::Nothing
+	end
+
+	test "#<=>" do
+		expect(some_val_1 <=> some_int_monad.new(1)) == 0
+		expect(some_val_1 <=> some_int_monad.new(2)) == -1
+		expect(some_val_1 <=> some_int_monad.new(0)) == 1
+		expect(some_val_1 <=> 1) == nil
+		expect(some_val_1 <=> Literal::Nothing) == nil
+	end
+
+	# Test for Comparable
+
+	test "#between?" do
+		assert some_val_1.between?(some_int_monad.new(0), some_int_monad.new(1))
+		refute some_val_1.between?(some_val_2, some_int_monad.new(3))
+		expect { some_val_1.between?(some_val_1, Literal::Nothing) }.to_raise ArgumentError
+	end
+
+	test "#<" do
+		assert some_val_1 < some_int_monad.new(2)
+		refute some_val_1 < some_int_monad.new(1)
+	end
+
+	test "#<=" do
+		assert some_val_1 <= some_int_monad.new(1)
+		refute some_val_1 <= some_int_monad.new(0)
+	end
+
+	test "#>" do
+		assert some_val_1 > some_int_monad.new(0)
+		refute some_val_1 > some_int_monad.new(1)
+	end
+
+	test "#>=" do
+		assert some_val_1 >= some_int_monad.new(1)
+		refute some_val_1 >= some_val_2
+	end
+
+	test "#clamp" do
+		expect(some_val_1.clamp(some_int_monad.new(0), some_int_monad.new(1))) == some_val_1
+		expect(some_val_1.clamp(some_val_2, some_int_monad.new(3))) == some_val_2
+	end
 end


### PR DESCRIPTION
For Some, `<=>` and `eql?` depend on its value, making them more 'value class' like

Fixes #32 