### PR TITLE
fix `lift!` behavior without `.failure` case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.idea/
 /.yardoc
 /_yardoc/
 /coverage/

--- a/lib/literal/lift.rb
+++ b/lib/literal/lift.rb
@@ -57,7 +57,7 @@ class Literal::Lift
 			return block.call(value) if condition === value
 		end
 
-		return @failure_case&.call(value)
+		return @failure_case.call(value) if @failure_case
 
 		raise(value)
 	end


### PR DESCRIPTION
`return @failure_case&.call(value)` will return `nil` before it gets to the `raise` when not supplied a `.failure` block calling `.lift!`