### PR TITLE
Literal Futures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
   remote: .
   specs:
     literal (0.1.0)
+      async
       concurrent-ruby (~> 1.2)
       zeitwerk (~> 2.6)
 
@@ -17,6 +18,11 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    async (2.6.4)
+      console (~> 1.10)
+      fiber-annotation
+      io-event (~> 1.1)
+      timers (~> 4.1)
     backport (1.2.0)
     benchmark (0.2.1)
     benchmark-ips (2.11.0)
@@ -49,8 +55,10 @@ GEM
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     e2mmap (0.1.0)
+    fiber-annotation (0.2.0)
     fiber-local (1.0.0)
     ice_nine (0.11.2)
+    io-event (1.3.2)
     jaro_winkler (1.5.4)
     json (2.6.3)
     kramdown (2.4.0)
@@ -113,6 +121,7 @@ GEM
       yard (~> 0.9, >= 0.9.24)
     thor (1.2.1)
     tilt (2.1.0)
+    timers (4.3.5)
     unicode-display_width (2.4.2)
     webrick (1.8.1)
     yard (0.9.34)

--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "zeitwerk"
+require "async"
 require "concurrent-ruby"
 
 module Literal

--- a/lib/literal/constructors.rb
+++ b/lib/literal/constructors.rb
@@ -1,9 +1,20 @@
 # frozen_string_literal: true
 
 module Literal::Constructors
-	# @return [Literal::Array]
 	def Array(type)
 		Literal::ArrayType.new(type)
+	end
+
+	def Future(type)
+		Literal::FutureType.new(type)
+	end
+
+	def FutureProxy(type)
+		Literal::FutureProxyType.new(type)
+	end
+
+	def FutureEnumerable(type)
+		Literal::FutureEnumerableType.new(type)
 	end
 
 	# @return [Literal::LRU]

--- a/lib/literal/future.rb
+++ b/lib/literal/future.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Literal::Future
+	def initialize(type, task)
+		@type = type
+		@task = task
+	end
+
+	attr_reader :type
+
+	def wait
+		output = @task.wait
+		if @type === output
+			output
+		else
+			raise Literal::TypeError.expected(output, to_be_a: @type)
+		end
+	end
+
+	def running?
+		@task.running?
+	end
+
+	def then(type)
+		output = yield(wait)
+
+		if type === output
+			output
+		else
+			raise Literal::TypeError.expected(output, to_be_a: type)
+		end
+	end
+end

--- a/lib/literal/future_enumerable.rb
+++ b/lib/literal/future_enumerable.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Literal::FutureEnumerable
+	include Enumerable
+	def initialize(type, task)
+		@type = type
+		@task = task
+	end
+
+	attr_reader :type
+
+	def each
+		output = @task.wait
+
+		if Enumerable === output
+			output.each do |item|
+				if @type === item
+					yield(item)
+				else
+					raise ::Literal::TypeError.expected(item, to_be_a: @type)
+				end
+			end
+		else
+			raise Literal::TypeError.expected(output, to_be_a: Enumerable)
+		end
+
+		self
+	end
+end

--- a/lib/literal/future_enumerable_type.rb
+++ b/lib/literal/future_enumerable_type.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Literal::FutureEnumerableType
+	def initialize(type)
+		@type = type
+	end
+
+	def inspect
+		"Literal::FutureEnumerable(#{@type.inspect})"
+	end
+
+	def ===(other)
+		Literal::FutureEnumerable === other && @type == other.type
+	end
+
+	def new(&)
+		Literal::FutureEnumerable.new(@type, Async(&))
+	end
+end

--- a/lib/literal/future_proxy.rb
+++ b/lib/literal/future_proxy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Literal::FutureProxy < BasicObject
+	def initialize(type, task)
+		@type = type
+		@task = task
+	end
+
+	attr_reader :type
+
+	def method_missing(...)
+		output = @task.wait
+		if @type === output
+			output.public_send(...)
+		else
+			raise ::Literal::TypeError.expected(output, to_be_a: @type)
+		end
+	end
+end

--- a/lib/literal/future_proxy_type.rb
+++ b/lib/literal/future_proxy_type.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Literal::FutureProxyType
+	def initialize(type)
+		@type = type
+	end
+
+	attr_reader :type
+
+	def inspect
+		"Literal::FutureProxy(#{@type.inspect})"
+	end
+
+	def ===(other)
+		Literal::FutureProxy === other && @type == other.type
+	end
+
+	def new(&)
+		Literal::FutureProxy.new(@type, Async(&))
+	end
+end

--- a/lib/literal/future_type.rb
+++ b/lib/literal/future_type.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Literal::FutureType
+	def initialize(type)
+		@type = type
+	end
+
+	def inspect
+		"Literal::Future(#{@type.inspect})"
+	end
+
+	def ===(other)
+		Literal::Future === other && @type == other.type
+	end
+
+	def new(&)
+		Literal::Future.new(@type, Async(&))
+	end
+end

--- a/literal.gemspec
+++ b/literal.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 	# Uncomment to register a new dependency of your gem
 	spec.add_dependency "concurrent-ruby", "~> 1.2"
 	spec.add_dependency "zeitwerk", "~> 2.6"
+	spec.add_dependency "async"
 
 	# For more information and examples about making a new gem, check out our
 	# guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Literal futures are a wrapper around [async](https://github.com/socketry/async) tasks, providing typed future values.

### Literal::Future

You can create a future like this

```ruby
future = Literal::Future(User).new { get_user_from_api }
```

It will immediately begin executing in the background. When you wait for it to read its value, the result will be checked against the expected type.

```ruby
future.wait
```

### Literal::FutureProxy

Like `Literal::Future`, only it uses `method_missing` to delegate methods to the output of the internal task.

```ruby
user = Literal::FutureProxy(User).new { get_user_from_api }

# Later, calling `name` is blocking
puts user.name
```

### Literal::FutureEnumerable

This is like a `Literal::FutureProxy`, but instead of delegating all methods with `method_missing`, it only delegates `each`. `Literal::FutureEnumerable` includes `Enumerable`, so it responds to all the normal enumerable methods.

The result of the task must return an `Enumerable` object, and each object must match the expected type.

```ruby
users = Literal::FutureEnumerable(User) { get_users_from_api }
```