### PR TITLE
Enums tweaks

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,28 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.2']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: bundle exec gd

--- a/bin/console
+++ b/bin/console
@@ -4,6 +4,8 @@
 require "bundler/setup"
 require "literal"
 
+Zeitwerk::Loader.eager_load_all
+
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -11,7 +11,7 @@ class Literal::Enum
 		def respond_to_missing?(name)
 			return super if frozen?
 			return super unless Symbol === name
-			return super unless name[0] =~ /[A-Z]/
+			return super unless ("A".."Z").include? name[0]
 
 			true
 		end

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -59,6 +59,10 @@ class Literal::Enum
 		end
 
 		alias_method :cast, :[]
+
+		def to_proc
+			method(:cast).to_proc
+		end
 	end
 
 	def initialize(name, value, &block)

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -37,7 +37,7 @@ class Literal::Enum
 			@values[value] = member
 			@members << member
 
-			define_method("#{name.to_s.downcase.gsub(/(?<=[A-Z])(?=[A-Z][a-z])|(?<=[a-z\d])(?=[A-Z])/, '_')}?") { self == member }
+			define_method("#{name.to_s.gsub(/([^A-Z])([A-Z]+)/, '\1_\2').downcase}?") { self == member }
 		end
 
 		def deep_freeze

--- a/test/literal/enum.test.rb
+++ b/test/literal/enum.test.rb
@@ -1,7 +1,33 @@
 # frozen_string_literal: true
 
+extend Literal::Types
+
 Color = Literal::Enum(Integer).define do
 	Red(0)
 	Green(1)
 	Blue(3)
+	LightRed(4)
+end
+
+Switch = Literal::Enum(_Boolean).define do
+	On(true)
+	Off(false)
+end
+
+test do
+	color = Color::Red
+	assert color.is_a?(Color)
+	assert color.red?
+	refute color.light_red?
+	expect(color.value) == 0
+	expect(color.to_i) == 0
+
+	expect(Color.cast(4)) == Color::LightRed
+
+	on = Switch::On
+	assert on.on?
+	refute on.off?
+	refute on.respond_to?(:to_i)
+
+  expect(Color.reject { |c| c.red? }) == [Color::Green, Color::Blue, Color::LightRed]
 end

--- a/test/literal/enum.test.rb
+++ b/test/literal/enum.test.rb
@@ -30,4 +30,6 @@ test do
 	refute on.respond_to?(:to_i)
 
   expect(Color.reject { |c| c.red? }) == [Color::Green, Color::Blue, Color::LightRed]
+
+  expect([0, 4].map(&Color)) == [Color::Red, Color::LightRed]
 end

--- a/test/literal/enum.test.rb
+++ b/test/literal/enum.test.rb
@@ -14,26 +14,6 @@ Switch = Literal::Enum(_Boolean).define do
 	Off(false)
 end
 
-test do
-	color = Color::Red
-	assert color.is_a?(Color)
-	assert color.red?
-	refute color.light_red?
-	expect(color.value) == 0
-	expect(color.to_i) == 0
-
-	expect(Color.cast(4)) == Color::LightRed
-
-	on = Switch::On
-	assert on.on?
-	refute on.off?
-	refute on.respond_to?(:to_i)
-
-  expect(Color.reject { |c| c.red? }) == [Color::Green, Color::Blue, Color::LightRed]
-
-  expect([0, 4].map(&Color)) == [Color::Red, Color::LightRed]
-end
-
 test "handle" do
 	output = Color::Red.handle do |c|
 		c.when(Color::Red) { "red" }
@@ -51,6 +31,7 @@ end
 test "the enum class is enumerable" do
 	expect(Color).to_be_an Enumerable
 	expect(Color.map(&:value)) == [0, 1, 3]
+	expect(Color.reject { |c| c.red? }) == [Color::Green, Color::Blue, Color::LightRed]
 end
 
 test "type checking" do
@@ -111,4 +92,14 @@ test "casting a value" do
 	expect(Color[0]) == Color::Red
 	expect(Color[1]) == Color::Green
 	expect(Color[3]) == Color::Blue
+	expect(Color.cast(4)) == Color::LightRed
+end
+
+test "to_i is defined on integer enums" do
+	expect(Color::Red.to_i) == 0
+	refute Switch::On.respond_to?(:to_i)
+end
+
+test "enum can be used as a proc to cast values" do
+	expect([0, 4].map(&Color)) == [Color::Red, Color::LightRed]
 end


### PR DESCRIPTION
Tweaks implementation regexs, adds `.to_proc` as alias to `cast` so you can do something like `[0, 4].map(&Color)) ` => ` [Color::Red, Color::LightRed]`