### PR TITLE
Define enums as normal classes

### DIFF
--- a/lib/literal/array_type.rb
+++ b/lib/literal/array_type.rb
@@ -11,7 +11,11 @@ class Literal::ArrayType < Literal::Generic
 	def ===(value)
 		case value
 		when Literal::Array
-			@type == value.type
+			if @type == value.type
+				true
+			elsif Module === @type && Module === value.type && (value.type < @type)
+				true
+			end
 		else
 			false
 		end

--- a/lib/literal/constructors.rb
+++ b/lib/literal/constructors.rb
@@ -1,13 +1,34 @@
 # frozen_string_literal: true
 
 module Literal::Constructors
+	SpecialisedEnums = {
+		String => Class.new(Literal::Enum) do
+			def type = String
+			alias_method :to_s, :value
+			alias_method :to_str, :value
+		end,
+
+		Integer => Class.new(Literal::Enum) do
+			def type = Integer
+			alias_method :to_i, :value
+		end,
+
+		Array => Class.new(Literal::Enum) do
+			def type = Array
+			alias_method :to_a, :value
+			alias_method :to_ary, :value
+		end
+	}.freeze
+
 	# @return [Literal::Array]
 	def Array(type)
 		Literal::ArrayType.new(type)
 	end
 
 	def Enum(type)
-		Literal::EnumType.new(type)
+		SpecialisedEnums[type] || Class.new(Literal::Enum) do
+			define_method(:type) { type }
+		end
 	end
 
 	# @return [Literal::LRU]

--- a/lib/literal/enum_type.rb
+++ b/lib/literal/enum_type.rb
@@ -18,8 +18,6 @@ class Literal::EnumType < Literal::Type
 
 		Class.new(Literal::Enum) do
 			@type = type
-			@values = {}
-			@members = []
 
 			if Integer == type
 				alias_method :to_i, :value

--- a/test/literal/array.test.rb
+++ b/test/literal/array.test.rb
@@ -2,6 +2,10 @@
 
 let def whatever = Literal::Array(Integer).new(1, 2, 3)
 
+test "variance" do
+	assert Literal::Array(Object) === Literal::Array(Integer).new
+end
+
 describe "#<<" do
 	test "with valid item" do
 		whatever << 4

--- a/test/literal/enum.test.rb
+++ b/test/literal/enum.test.rb
@@ -2,14 +2,14 @@
 
 extend Literal::Types
 
-Color = Literal::Enum(Integer).define do
+class Color < Literal::Enum(Integer)
 	Red(0)
 	Green(1)
 	Blue(3)
 	LightRed(4)
 end
 
-Switch = Literal::Enum(_Boolean).define do
+class Switch < Literal::Enum(_Boolean)
 	On(true) do
 		def toggle = Switch::Off
 	end
@@ -37,12 +37,12 @@ end
 test "the enum class is enumerable" do
 	expect(Color).to_be_an Enumerable
 	expect(Color.map(&:value)) == [0, 1, 3, 4]
-	expect(Color.reject { |c| c.red? }) == [Color::Green, Color::Blue, Color::LightRed]
+	expect(Color.reject(&:red?)) == [Color::Green, Color::Blue, Color::LightRed]
 end
 
 test "type checking" do
 	expect {
-		Literal::Enum(Integer).define do
+		class TypeChecking < Literal::Enum(Integer)
 			Red("red")
 		end
 	}.to_raise(Literal::TypeError)
@@ -56,7 +56,7 @@ end
 
 test "you can't use the same name twice" do
 	expect {
-		Literal::Enum(Integer).define do
+		class SameNameTwice < Literal::Enum(Integer)
 			Red(0)
 			Red(1)
 		end
@@ -65,7 +65,7 @@ end
 
 test "you can't use the same value twice" do
 	expect {
-		Literal::Enum(Integer).define do
+		class SameValueTwice < Literal::Enum(Integer)
 			Red(0)
 			Green(0)
 		end
@@ -87,11 +87,11 @@ test "predicates" do
 end
 
 test "values are frozen" do
-	Example = Literal::Enum(String).define do
+	class ValuesAreFrozen < Literal::Enum(String)
 		Foo(+"foo")
 	end
 
-	assert Example::Foo.value.frozen?
+	assert ValuesAreFrozen::Foo.value.frozen?
 end
 
 test "casting a value" do


### PR DESCRIPTION
With this change, you can now define Enums more like normal classes.

```ruby
class Color < Literal::Enum(Integer)
  Red(0)
  Green(1)
  Blue(2)
end
```

This allows you to use relative constants, e.g.

```ruby
class Switch < Literal::Enum(_Boolean)
  On(true) do
    def toggle = Off
  end

  Off(false) do
    def toggle = On
  end
end
```