### PR TITLE
Literal::Enum indexes

### DIFF
--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Literal::Enum
+	extend Literal::Types
 	include Literal::ModuleDefined
 
 	IndexDefinition = Data.define(:name, :type, :unique, :proc)

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -24,8 +24,6 @@ class Literal::Enum
 			subclass.instance_exec do
 				@values = {}
 				@members = []
-				@index_definitions = {}
-				@indexes = {}
 			end
 		end
 
@@ -56,6 +54,9 @@ class Literal::Enum
 		def index(name, type, unique: false, &block)
 			raise ArgumentError unless Symbol === name
 			raise ArgumentError if frozen?
+
+			@index_definitions ||= {}
+			@indexes = {}
 
 			@index_definitions[name] = IndexDefinition.new(
 				name:, type:, unique:, proc: block || name.to_proc

--- a/lib/literal/module_defined.rb
+++ b/lib/literal/module_defined.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Literal::ModuleDefined
+	module ClassMethods
+		def after_defined
+		end
+	end
+
+	def self.included(klass)
+		klass.extend(ClassMethods)
+	end
+end
+
+TracePoint.trace(:end) do |tp|
+	if Class === tp.self && tp.self < Literal::ModuleDefined
+		tp.self.after_defined
+	end
+end

--- a/test/literal/enum.test.rb
+++ b/test/literal/enum.test.rb
@@ -3,10 +3,27 @@
 extend Literal::Types
 
 class Color < Literal::Enum(Integer)
-	Red(0)
-	Green(1)
-	Blue(3)
-	LightRed(4)
+	index :rgb
+
+	index :hex do |color|
+		color.rgb.map { |c| c.to_s(16).rjust(2, "0") }.join
+	end
+
+	Red(0) do
+		def rgb = [255, 0, 0]
+	end
+
+	Green(1) do
+		def rgb = [0, 255, 0]
+	end
+
+	Blue(3) do
+		def rgb = [0, 0, 255]
+	end
+
+	LightRed(4) do
+		def rgb = [255, 128, 128]
+	end
 end
 
 class Switch < Literal::Enum(_Boolean)
@@ -17,6 +34,16 @@ class Switch < Literal::Enum(_Boolean)
 	Off(false) do
 		def toggle = Switch::On
 	end
+end
+
+test "index" do
+	expect(
+		Color.where(rgb: [0, 0, 255])
+	) == [Color::Blue]
+
+	expect(
+		Color.where(hex: "0000ff")
+	) == [Color::Blue]
 end
 
 test "handle" do

--- a/test/literal/enum.test.rb
+++ b/test/literal/enum.test.rb
@@ -3,26 +3,29 @@
 extend Literal::Types
 
 class Color < Literal::Enum(Integer)
-	index :rgb
+	attr_accessor :rgb
 
-	index :hex do |color|
-		color.rgb.map { |c| c.to_s(16).rjust(2, "0") }.join
+	index :rgb, Array, unique: true
+	index :hex, String, unique: true
+
+	def hex
+		rgb.map { |c| c.to_s(16).rjust(2, "0") }.join
 	end
 
 	Red(0) do
-		def rgb = [255, 0, 0]
+		self.rgb = [255, 0, 0]
 	end
 
 	Green(1) do
-		def rgb = [0, 255, 0]
+		self.rgb = [0, 255, 0]
 	end
 
 	Blue(3) do
-		def rgb = [0, 0, 255]
+		self.rgb = [0, 0, 255]
 	end
 
 	LightRed(4) do
-		def rgb = [255, 128, 128]
+		self.rgb = [255, 128, 128]
 	end
 end
 

--- a/test/literal/enum.test.rb
+++ b/test/literal/enum.test.rb
@@ -39,7 +39,7 @@ class Switch < Literal::Enum(_Boolean)
 	end
 end
 
-test "index" do
+test "where" do
 	expect(
 		Color.where(rgb: [0, 0, 255])
 	) == [Color::Blue]
@@ -47,6 +47,16 @@ test "index" do
 	expect(
 		Color.where(hex: "0000ff")
 	) == [Color::Blue]
+end
+
+test "find_by" do
+	expect(
+		Color.find_by(rgb: [0, 0, 255])
+	) == Color::Blue
+
+	expect(
+		Color.find_by(hex: "0000ff")
+	) == Color::Blue
 end
 
 test "handle" do


### PR DESCRIPTION
In this PR, I’m adding an `index` macro to `Enum`, which allows you to generate Hash indexes for `O(1)` lookups. The index can be generated from any attribute or Proc calculation on a member.

```ruby
class Language < Literal::Enum(Integer)
  index :name, String, unique: true

  EN(0) do
    def name = "English"
  end

  FR(1) do
    def name = "French"
  end
end

Language.where(name: "English") # => [Language::EN]
Language.find_by(name: "English") # => Language::EN
```

You can only use `find_by` for unique indexes.

The indexes are generated using a Proc, which defaults to `name.to_proc`, however you a pass a block instead.

```ruby
index :name, String, unique: true do |language|
  language.name.upcase
end
```