### PR TITLE
Literal::DataEnums

### DIFF
--- a/lib/literal/attributable.rb
+++ b/lib/literal/attributable.rb
@@ -44,6 +44,16 @@ module Literal::Attributable
 		define_literal_methods(attribute)
 	end
 
+	def inherited(subclass)
+		literal_attributes = self.literal_attributes
+
+		subclass.instance_exec do
+			@literal_attributes = literal_attributes.dup
+		end
+
+		super
+	end
+
 	def literal_attributes
 		return @literal_attributes if defined?(@literal_attributes)
 

--- a/lib/literal/data_enum.rb
+++ b/lib/literal/data_enum.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+class Literal::DataEnum < Literal::Data
+	include Literal::ModuleDefined
+
+	Index = Data.define(:name, :type, :unique, :block)
+
+	@index_definitions = {}
+
+	class << self
+		include Enumerable
+
+		def inherited(subclass)
+			index_definitions = @index_definitions
+
+			subclass.instance_exec do
+				@data = []
+				@index_definitions = index_definitions.dup
+				@indexes = {}
+			end
+
+			super
+		end
+
+		def define(...)
+			@data << new(...)
+		end
+
+		def new(...)
+			raise ArgumentError if frozen?
+
+			super
+		end
+
+		def allocate(...)
+			raise ArgumentError if frozen?
+
+			super
+		end
+
+		def index(name, type, unique: false, &block)
+			@index_definitions[name] = Index.new(name:, type:, unique:, block: block || name.to_proc)
+		end
+
+		def each(&)
+			@data.each(&)
+		end
+
+		def where(**kwargs)
+			unless kwargs.length == 1
+				raise ArgumentError, "You can only specify one index when using `where`."
+			end
+
+			key, value = kwargs.first
+
+			unless @index_definitions.fetch(key).type === value
+				raise Literal::TypeError.expected(value, to_be_a: @index_definitions.fetch(key).type)
+			end
+
+			@indexes.fetch(key)[value]
+		end
+
+		def find_by(**kwargs)
+			unless kwargs.length == 1
+				raise ArgumentError, "You can only specify one index when using `where`."
+			end
+
+			key, value = kwargs.first
+
+			unless @index_definitions.fetch(key).unique
+				raise ArgumentError, "You can only use `find_by` on unique indexes."
+			end
+
+			unless @index_definitions.fetch(key).type === value
+				raise Literal::TypeError.expected(value, to_be_a: @index_definitions.fetch(key).type)
+			end
+
+			@indexes.fetch(key)[value]&.first
+		end
+
+		def after_defined
+			raise ArgumentError if frozen?
+
+			build_indexes
+			@data.freeze
+			freeze
+		end
+
+		private def build_indexes
+			@index_definitions.each_value do |definition|
+				index = @data.group_by(&definition.block).freeze
+
+				index.each do |key, values|
+					unless definition.type === key
+						raise Literal::TypeError.expected(key, to_be_a: definition.type)
+					end
+
+					if definition.unique && values.size > 1
+						raise ArgumentError, "The index #{definition.name} is not unique."
+					end
+				end
+
+				@indexes[definition.name] = index
+			end
+		end
+
+		def [](index)
+			@data[index]
+		end
+
+		def size
+			@data.size
+		end
+	end
+end

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -52,63 +52,8 @@ class Literal::Enum
 			define_method("#{name.to_s.gsub(/([^A-Z])([A-Z]+)/, '\1_\2').downcase}?") { self == member }
 		end
 
-		def index(name, type, unique: false, &block)
-			raise ArgumentError unless Symbol === name
-			raise ArgumentError if frozen?
-
-			@index_definitions ||= {}
-			@indexes = {}
-
-			@index_definitions[name] = IndexDefinition.new(
-				name:, type:, unique:, proc: block || name.to_proc
-			)
-		end
-
-		def where(**kwargs)
-			unless kwargs.length == 1
-				raise ArgumentError, "You can only specify one index when using `where`."
-			end
-
-			key, value = kwargs.first
-
-			@indexes.fetch(key)[value]
-		end
-
-		def find_by(**kwargs)
-			unless kwargs.length == 1
-				raise ArgumentError, "You can only specify one index when using `find_by`."
-			end
-
-			key, value = kwargs.first
-
-			unless @index_definitions.fetch(key).unique
-				raise ArgumentError, "You can only use `find_by` on unique indexes."
-			end
-
-			@indexes.fetch(key)[value]&.first
-		end
-
 		def after_defined
 			raise ArgumentError if frozen?
-
-			@index_definitions&.each_value do |definition|
-				index = @members.group_by(&definition.proc).freeze
-
-				index.each do |key, value|
-					unless definition.type === key
-						raise Literal::TypeError.expected(key, to_be_a: definition.type)
-					end
-
-					if definition.unique && value.length > 1
-						raise ArgumentError, "Index #{name} is not unique for #{key}."
-					end
-				end
-
-				@indexes[definition.name] = index
-			end
-
-			@index_definitions.freeze
-			@indexes.freeze
 
 			@values.freeze
 			@members.freeze

--- a/test/literal/data_enum.test.rb
+++ b/test/literal/data_enum.test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Error < Literal::DataEnum
+	attribute :name, String
+	attribute :message, String
+
+	index :name, String, unique: true
+
+	define(
+		name: "Connection Error",
+		message: "There was a problem connecting to the server."
+	)
+
+	define(
+		name: "Authentication Error",
+		message: "There was a problem authenticating with the server."
+	)
+end
+
+test do
+	assert Error.frozen?
+	assert Error[0].frozen?
+
+	expect(
+		Error.find_by(name: "Connection Error")
+	) == Error[0]
+
+	expect(
+		Error.where(name: "Connection Error")
+	) == [Error[0]]
+end

--- a/test/literal/enum.test.rb
+++ b/test/literal/enum.test.rb
@@ -3,30 +3,10 @@
 extend Literal::Types
 
 class Color < Literal::Enum(Integer)
-	attr_accessor :rgb
-
-	index :rgb, Array, unique: true
-	index :hex, String, unique: true
-
-	def hex
-		rgb.map { |c| c.to_s(16).rjust(2, "0") }.join
-	end
-
-	Red(0) do
-		self.rgb = [255, 0, 0]
-	end
-
-	Green(1) do
-		self.rgb = [0, 255, 0]
-	end
-
-	Blue(3) do
-		self.rgb = [0, 0, 255]
-	end
-
-	LightRed(4) do
-		self.rgb = [255, 128, 128]
-	end
+	Red(0)
+	Green(1)
+	Blue(3)
+	LightRed(4)
 end
 
 class Switch < Literal::Enum(_Boolean)
@@ -37,26 +17,6 @@ class Switch < Literal::Enum(_Boolean)
 	Off(false) do
 		def toggle = Switch::On
 	end
-end
-
-test "where" do
-	expect(
-		Color.where(rgb: [0, 0, 255])
-	) == [Color::Blue]
-
-	expect(
-		Color.where(hex: "0000ff")
-	) == [Color::Blue]
-end
-
-test "find_by" do
-	expect(
-		Color.find_by(rgb: [0, 0, 255])
-	) == Color::Blue
-
-	expect(
-		Color.find_by(hex: "0000ff")
-	) == Color::Blue
 end
 
 test "handle" do


### PR DESCRIPTION
I’ve removed the `index` feature from #64 and added a new kind of enum that's better for working with static enumerations of data objects. Standard enums are better for simple key/value enumerations and IMO don't need indexes.