### PR TITLE
Structish classes should define eql?

### DIFF
--- a/lib/literal/structish.rb
+++ b/lib/literal/structish.rb
@@ -18,6 +18,8 @@ class Literal::Structish
 		end
 	end
 
+	alias_method :eql?, :==
+
 	def [](key)
 		@attributes[key]
 	end

--- a/lib/literal/structish.rb
+++ b/lib/literal/structish.rb
@@ -18,7 +18,9 @@ class Literal::Structish
 		end
 	end
 
-	alias_method :eql?, :==
+	def eql?(other)
+		self == other
+	end
 
 	def [](key)
 		@attributes[key]

--- a/test/literal/struct.test.rb
+++ b/test/literal/struct.test.rb
@@ -38,6 +38,18 @@ test "#eql? compares attributes" do
 	refute(person.eql?(another))
 end
 
+class StudentStruct < PersonStruct
+	def ==(other)
+		super && other.is_a?(StudentStruct)
+	end
+end
+
+test "#eql? works with subclass overrides #==" do
+	person = PersonStruct.new(name: "John", age: 30)
+	student = StudentStruct.new(name: "John", age: 30)
+	refute(student.eql? person)
+end
+
 test "does not freeze attribute values" do
 	person = PersonStruct.new(name: "John", age: 30, settings: { x: 1 })
 	expect(person.settings).not_to_be :frozen?

--- a/test/literal/struct.test.rb
+++ b/test/literal/struct.test.rb
@@ -22,6 +22,22 @@ test "#to_h returns attributes as new hash" do
 	expect(hash).not_to_be :frozen?
 end
 
+test "#== compares attributes" do
+	person = PersonStruct.new(name: "John", age: 30)
+	other = PersonStruct.new(name: "John", age: 30)
+	another = PersonStruct.new(name: "John", age: 40)
+	assert(person == other)
+	refute(person == another)
+end
+
+test "#eql? compares attributes" do
+	person = PersonStruct.new(name: "John", age: 30)
+	other = PersonStruct.new(name: "John", age: 30)
+	another = PersonStruct.new(name: "John", age: 40)
+	assert(person.eql?(other))
+	refute(person.eql?(another))
+end
+
 test "does not freeze attribute values" do
 	person = PersonStruct.new(name: "John", age: 30, settings: { x: 1 })
 	expect(person.settings).not_to_be :frozen?


### PR DESCRIPTION
as per Ruby docs, mostly this is just an alias of #==