### PR TITLE
Update jaro_winkler development version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     e2mmap (0.1.0)
     fiber-local (1.0.0)
     ice_nine (0.11.2)
-    jaro_winkler (1.5.4)
+    jaro_winkler (1.5.6)
     json (2.6.3)
     kramdown (2.4.0)
       rexml


### PR DESCRIPTION
The jaro_winkler library has an error when compiling on LLVM 15.