### PR TITLE
Better Enums

### DIFF
--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -21,7 +21,7 @@ module Literal
 
 	def self.Enum(type)
 		Class.new(Literal::Enum) do
-			@type = type
+			prop :value, type, :positional
 		end
 	end
 

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -156,6 +156,15 @@ class Literal::Enum
 
 	alias_method :inspect, :name
 
+	def deconstruct
+		[value]
+	end
+
+	def deconstruct_keys(keys)
+		h = to_h
+		keys ? h.slice(*keys) : h
+	end
+
 	def _dump(level)
 		Marshal.dump(@value)
 	end

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -3,17 +3,6 @@
 class Literal::Enum
 	extend Literal::Properties
 
-	class Index
-		def initialize(unique:)
-			@unique = unique
-			@values = {}
-		end
-
-		def [](key)
-			@values[key]
-		end
-	end
-
 	class << self
 		include Enumerable
 
@@ -135,6 +124,10 @@ class Literal::Enum
 		end
 
 		alias_method :cast, :[]
+
+		def fetch(...)
+			@values.fetch(...)
+		end
 
 		def to_proc
 			method(:cast).to_proc

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
-TracePoint.trace(:end) do |tp|
-	it = tp.self
+class Literal::Enum < Literal::Struct
+	class Index
+		def initialize(unique:)
+			@unique = unique
+			@values = {}
+		end
 
-	if Class === it && it < Literal::Enum
-		it.__after_defined__
+		def [](key)
+			@values[key]
+		end
 	end
-end
-
-class Literal::Enum
-	extend Literal::Types
 
 	class << self
 		include Enumerable
@@ -18,52 +19,98 @@ class Literal::Enum
 
 		def values = @values.keys
 
-		def respond_to_missing?(name, include_private = false)
-			return super if frozen?
-			return super unless Symbol === name
-			return super unless ("A".."Z").include? name[0]
-
-			true
-		end
-
 		def inherited(subclass)
-			type = @type
-
 			subclass.instance_exec do
 				@values = {}
 				@members = Set[]
-				@type = type
+				@indexes = {}
+				@index = {}
 			end
+		end
+
+		def index(name, type, unique: true, &block)
+			@indexes[name] = [type, unique, block || name.to_proc]
+		end
+
+		def where(**kwargs)
+			unless kwargs.length == 1
+				raise ArgumentError, "You can only specify one index when using `where`."
+			end
+
+			key, value = kwargs.first
+
+			unless (type = @indexes.fetch(key)[0]) === value
+				raise Literal::TypeError.expected(value, to_be_a: type)
+			end
+
+			@index.fetch(key)[value]
+		end
+
+		def find_by(**kwargs)
+			unless kwargs.length == 1
+				raise ArgumentError, "You can only specify one index when using `where`."
+			end
+
+			key, value = kwargs.first
+
+			unless @indexes.fetch(key)[1]
+				raise ArgumentError, "You can only use `find_by` on unique indexes."
+			end
+
+			unless (type = @indexes.fetch(key)[0]) === value
+				raise Literal::TypeError.expected(value, to_be_a: type)
+			end
+
+			@index.fetch(key)[value]&.first
 		end
 
 		def _load(data)
 			self[Marshal.load(data)]
 		end
 
-		def method_missing(name, value, *args, **kwargs, &)
-			return super if frozen?
-			return super unless name.is_a?(Symbol)
-			return super unless name[0] == name[0].upcase
-			return super if args.length > 0
-			return super if kwargs.length > 0
+		def const_added(name)
+			raise ArgumentError if frozen?
+			object = const_get(name)
 
-			raise ArgumentError if @values.key? value
-			raise ArgumentError if constants.include?(name)
+			if self === object
+				@values[object.value] = object
+				@members << object
+				define_method("#{name.to_s.gsub(/([^A-Z])([A-Z]+)/, '\1_\2').downcase}?") { self == object }
+			end
+		end
 
-			value = value.dup.freeze unless value.frozen?
+		def new(*, **, &block)
+			raise ArgumentError if frozen?
+		  new_object = super(*, **, &nil)
 
-			Literal.check(value, @type)
+			if block
+				new_object.instance_exec(&block)
+			end
 
-			member = new(name, value, &)
-			const_set name, member
-			@values[value] = member
-			@members << member
-
-			define_method("#{name.to_s.gsub(/([^A-Z])([A-Z]+)/, '\1_\2').downcase}?") { self == member }
+			new_object.freeze
+			new_object
 		end
 
 		def __after_defined__
 			raise ArgumentError if frozen?
+
+
+			@indexes.each do |name, (type, unique, block)|
+				index = @members.group_by(&block).freeze
+
+				index.each do |key, values|
+					unless type === key
+						raise Literal::TypeError.expected(key, to_be_a: type)
+					end
+
+					if unique && values.size > 1
+						raise ArgumentError, "The index #{name} is not unique."
+					end
+				end
+
+				@index[name] = index
+			end
+
 
 			@values.freeze
 			@members.freeze
@@ -106,5 +153,13 @@ class Literal::Enum
 
 	def _dump(level)
 		Marshal.dump(@value)
+	end
+end
+
+TracePoint.trace(:end) do |tp|
+	it = tp.self
+
+	if Class === it && it < Literal::Enum
+		it.__after_defined__
 	end
 end

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -40,7 +40,7 @@ class Literal::Enum
 
 		def where(**kwargs)
 			unless kwargs.length == 1
-				raise ArgumentError, "You can only specify one index when using `where`."
+				raise ArgumentError.new("You can only specify one index when using `where`.")
 			end
 
 			key, value = kwargs.first
@@ -54,13 +54,13 @@ class Literal::Enum
 
 		def find_by(**kwargs)
 			unless kwargs.length == 1
-				raise ArgumentError, "You can only specify one index when using `where`."
+				raise ArgumentError.new("You can only specify one index when using `where`.")
 			end
 
 			key, value = kwargs.first
 
 			unless @indexes.fetch(key)[1]
-				raise ArgumentError, "You can only use `find_by` on unique indexes."
+				raise ArgumentError.new("You can only use `find_by` on unique indexes.")
 			end
 
 			unless (type = @indexes.fetch(key)[0]) === value
@@ -89,7 +89,7 @@ class Literal::Enum
 
 		def new(*, **, &block)
 			raise ArgumentError if frozen?
-		  new_object = super(*, **, &nil)
+			new_object = super(*, **, &nil)
 
 			if block
 				new_object.instance_exec(&block)
@@ -101,7 +101,6 @@ class Literal::Enum
 		def __after_defined__
 			raise ArgumentError if frozen?
 
-
 			@indexes.each do |name, (type, unique, block)|
 				index = @members.group_by(&block).freeze
 
@@ -111,13 +110,12 @@ class Literal::Enum
 					end
 
 					if unique && values.size > 1
-						raise ArgumentError, "The index #{name} is not unique."
+						raise ArgumentError.new("The index #{name} is not unique.")
 					end
 				end
 
 				@index[name] = index
 			end
-
 
 			@values.freeze
 			@members.freeze

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class Literal::Enum < Literal::Struct
+class Literal::Enum
+	extend Literal::Properties
+
 	class Index
 		def initialize(unique:)
 			@unique = unique
@@ -18,6 +20,10 @@ class Literal::Enum < Literal::Struct
 		attr_reader :members
 
 		def values = @values.keys
+
+		def prop(name, type, kind = :keyword, reader: :public, default: nil)
+			super(name, type, kind, reader:, writer: false, default:)
+		end
 
 		def inherited(subclass)
 			subclass.instance_exec do
@@ -73,9 +79,11 @@ class Literal::Enum < Literal::Struct
 			object = const_get(name)
 
 			if self === object
+				object.instance_variable_set(:@name, name)
 				@values[object.value] = object
 				@members << object
 				define_method("#{name.to_s.gsub(/([^A-Z])([A-Z]+)/, '\1_\2').downcase}?") { self == object }
+				object.freeze
 			end
 		end
 
@@ -87,7 +95,6 @@ class Literal::Enum < Literal::Struct
 				new_object.instance_exec(&block)
 			end
 
-			new_object.freeze
 			new_object
 		end
 

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -27,6 +27,7 @@ class Switch < Literal::Enum(_Boolean)
 end
 
 test do
+	expect(Color::Red.name) =~ /Color::Red\z/
 	expect(Color.where(hex: "#FF0000")) == [Color::Red]
 	expect(Color.find_by(hex: "#FF0000")) == Color::Red
 	expect { Color.find_by(lower_hex: "#ff0000")}.to_raise(ArgumentError)

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -30,7 +30,7 @@ test do
 	expect(Color::Red.name) =~ /Color::Red\z/
 	expect(Color.where(hex: "#FF0000")) == [Color::Red]
 	expect(Color.find_by(hex: "#FF0000")) == Color::Red
-	expect { Color.find_by(lower_hex: "#ff0000")}.to_raise(ArgumentError)
+	expect { Color.find_by(lower_hex: "#ff0000") }.to_raise(ArgumentError)
 	expect(Color.where(lower_hex: "#ff0000")) == [Color::Red]
 	expect(Color::Red.value) == 1
 	expect(Color::Red.hex) == "#FF0000"

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -47,3 +47,13 @@ test do
 	expect(Switch::Off.toggle) == Switch::On
 	expect(Switch::On.toggle) == Switch::Off
 end
+
+test "pattern matching" do
+	Color::Red => Color
+	Color::Red => Color[1]
+	Color::Red => Color[hex: "#FF0000"]
+
+	Color::Red => Color
+	Color::Red => Color[1]
+	Color::Red => Color::Red[hex: "#FF0000"]
+end

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -5,7 +5,11 @@ extend Literal::Types
 class Color < Literal::Enum(Integer)
 	prop :hex, String
 
-	index :hex, String, unique: true
+	index :hex, String
+
+	index :lower_hex, String, unique: false do |color|
+		color.hex.downcase
+	end
 
 	Red = new(1, hex: "#FF0000")
 	Green = new(2, hex: "#00FF00")
@@ -25,6 +29,8 @@ end
 test do
 	expect(Color.where(hex: "#FF0000")) == [Color::Red]
 	expect(Color.find_by(hex: "#FF0000")) == Color::Red
+	expect { Color.find_by(lower_hex: "#ff0000")}.to_raise(ArgumentError)
+	expect(Color.where(lower_hex: "#ff0000")) == [Color::Red]
 	expect(Color::Red.value) == 1
 	expect(Color::Red.hex) == "#FF0000"
 	expect(Color::Red.red?) == true

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -3,23 +3,30 @@
 extend Literal::Types
 
 class Color < Literal::Enum(Integer)
-	Red(1)
-	Green(2)
-	Blue(3)
+	prop :hex, String
+
+	index :hex, String, unique: true
+
+	Red = new(1, hex: "#FF0000")
+	Green = new(2, hex: "#00FF00")
+	Blue = new(3, hex: "#0000FF")
 end
 
 class Switch < Literal::Enum(_Boolean)
-	On(true) do
+	On = new(true) do
 		def toggle = Off
 	end
 
-	Off(false) do
+	Off = new(false) do
 		def toggle = On
 	end
 end
 
 test do
+	expect(Color.where(hex: "#FF0000")) == [Color::Red]
+	expect(Color.find_by(hex: "#FF0000")) == Color::Red
 	expect(Color::Red.value) == 1
+	expect(Color::Red.hex) == "#FF0000"
 	expect(Color::Red.red?) == true
 	expect(Color::Red.green?) == false
 	expect(Color).to_be(:frozen?)


### PR DESCRIPTION
This PR introduces a number of changes and improvements to Literal::Enums.

Literal::Enums no longer use `method_missing` to provide a "literal" syntax. Instead, you assign constants yourself.

```ruby
class Color < Literal::Enum(Integer)
  Red = new(1)
  Green = new(2)
  Blue = new(3)
end
```

The advantage to this is language servers can pick up the constants and they’ll know the types because of the call to `new`.

Every enum class has a `value` property which is specified in the class you inherit from. This will always be the first positional argument and it’s how the Enum can be efficiently coerced back and forth from a simple value for storage.

Enum classes will be frozen after definition, so you can’t add any new constants.

### Collection methods

You can look up a list of members or values:

```ruby
Color.members # => Set[Color::Red, Color::Green, Color::Blue]
```

They also enumerable so respond to `.each`, `.map`, etc.

```ruby
Color.map(&:value) # => [1, 2, 3]
```

Enumerable classes respond to `to_proc` so you can map values to enums
```ruby
[3, 2, 1].map(&Color) # => [Color::Green, Color::Blue, Color::Red]
```

### Member methods

On a given member, you can check properties, e.g.

```ruby
Color::Red.value # => 1
```

### Member singletons

You can define methods on members:

```ruby
class Switch < Literal::Enum(_Boolean)
  On = new(true) do
    def toggle = Off
  end

  Off = new(false) do
    def toggle = On
  end
end

Switch::Off.toggle # => Switch::On
```

### Custom properties

You can add your own properties

```ruby
class Color < Literal::Enum(Integer)
  prop :hex, String

  Red = new(1, hex: "#FF0000")
  Green = new(2, hex: "#00FF00")
  Blue = new(3, hex: "#0000FF")
end
```

### Indexes

You can add custom indexes

```ruby
class Country < Literal::Enum(Integer)
  prop :code, Symbol
  index :code, Symbol, unique: true

  UnitedKingdom = new(1, code: :uk)
  UnitedStates = new(2, code: :us)
end
```

Now you can look up members using `where` and `find_by`. `find_by` only works on unique indexes, while `where` works on any index.

```ruby
Country.find_by(code: :us) # => Country::UnitedStates
```

You can pass a block to create advanced indexes, e.g.

```ruby
index :country_code_length, Integer, unique: false do |country|
  country.code.length
end
```