### PR TITLE
Implement Enum.to_h

### DIFF
--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -132,6 +132,10 @@ class Literal::Enum
 		def to_proc
 			method(:cast).to_proc
 		end
+
+		def to_h(*args)
+			@values.dup
+		end
 	end
 
 	def initialize(name, value, &block)

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -41,6 +41,8 @@ test do
 	expect(Color[1]) == Color::Red
 	expect(Color.cast(1)) == Color::Red
 	expect(Color.to_set) == Set[Color::Red, Color::Green, Color::Blue]
+	expect(Color.to_h) == {1 => Color::Red, 2 => Color::Green, 3 => Color::Blue}
+	expect(Color.to_a) == [Color::Red, Color::Green, Color::Blue]
 	expect(Color.values) == [1, 2, 3]
 	expect([3, 2, 1].map(&Color)) == [Color::Blue, Color::Green, Color::Red]
 


### PR DESCRIPTION
It is possible to do `Enum.to_set` and `Enum.to_a` but not `Enum.to_h`

```
Switch.to_h
ruby/3.3.0/lib/ruby/3.3.0/set.rb:501:in `each_key': wrong element type Switch (expected array) (TypeError)

    @hash.each_key(&block)
                   ^^^^^^
```

We can implement it to either:

return a hash where the values are the keys and the Enum instances are the values. 

`{ true => Switch::On, false => Switch::Off }`

Or vice versa

`{ Switch::On => true, Switch::Off => false }`

The more semantically intuitive is the latter I think, but then again, `.[]` actually maps enum values to instances, so the former aligns better with that.

This PR implements it as the former, ie 

```
irb(main):007> Switch[true]
=> Switch::On
irb(main):008> Switch.to_h
=> {true=>Switch::On, false=>Switch::Off}
irb(main):009> Switch.to_h[true] 
=> Switch::On

```