### PR TITLE
Implement Enum#=== to support using enum instances in case statements…

### DIFF
--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -150,7 +150,7 @@ class Literal::Enum
 	alias_method :inspect, :name
 
 	def deconstruct
-		[value]
+		[@value]
 	end
 
 	def deconstruct_keys(keys)
@@ -160,6 +160,11 @@ class Literal::Enum
 
 	def _dump(level)
 		Marshal.dump(@value)
+	end
+
+	def ===(other)
+		return true if equal? other
+		@value == other
 	end
 end
 

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -26,6 +26,11 @@ class Switch < Literal::Enum(_Boolean)
 	end
 end
 
+class Choice < Literal::Enum(_Boolean)
+	Yes = new(true)
+	No = new(false)
+end
+
 test do
 	expect(Color::Red.name) =~ /Color::Red\z/
 	expect(Color.where(hex: "#FF0000")) == [Color::Red]
@@ -46,6 +51,17 @@ test do
 
 	expect(Switch::Off.toggle) == Switch::On
 	expect(Switch::On.toggle) == Switch::Off
+
+	assert Switch === Switch::On
+	assert Switch === Switch::Off
+	assert Switch.include? Switch::Off
+	assert Switch::On === true
+	assert Switch::On === Switch::On
+	assert Switch::Off === false
+
+	assert Switch::On.value == Choice::Yes.value
+	refute Switch::On === Choice::Yes
+	refute Switch === Choice::Yes
 end
 
 test "pattern matching" do
@@ -56,4 +72,28 @@ test "pattern matching" do
 	Color::Red => Color
 	Color::Red => Color[1]
 	Color::Red => Color::Red[hex: "#FF0000"]
+end
+
+test "case statement" do
+	v = case 1
+	in Choice::Yes
+		:yes
+	in Color::Red
+		:red
+	in Color::Green
+		:green
+	else
+		:other
+	end
+	expect(v) == :red
+
+	v = case 1
+	when Color::Red
+		:red
+	when Color::Green
+		:green
+	else
+		:other
+	end
+	expect(v) == :red
 end

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -46,7 +46,7 @@ test do
 	expect(Color[1]) == Color::Red
 	expect(Color.cast(1)) == Color::Red
 	expect(Color.to_set) == Set[Color::Red, Color::Green, Color::Blue]
-	expect(Color.to_h) == {1 => Color::Red, 2 => Color::Green, 3 => Color::Blue}
+	expect(Color.to_h) == { 1 => Color::Red, 2 => Color::Green, 3 => Color::Blue }
 	expect(Color.to_a) == [Color::Red, Color::Green, Color::Blue]
 	expect(Color.values) == [1, 2, 3]
 	expect([3, 2, 1].map(&Color)) == [Color::Blue, Color::Green, Color::Red]


### PR DESCRIPTION
… and some more checks and balances in test

I thought it might be cool if Enums could be used in case statements, but not sure if changing the exact semantics of `#===` makes sense. Here the implementation is basically, something is case equivalent/matches if its equal to enum instance itself (its is strictly equal), or its equal to the instance value.

Also I noticed `deconstruct` was using the attribute accessor, but is seems methods mostly use ivars directly so I changed it over