### PR TITLE
fix unstable sorting

### DIFF
--- a/lib/literal/properties/schema.rb
+++ b/lib/literal/properties/schema.rb
@@ -19,7 +19,9 @@ class Literal::Properties::Schema
 	def <<(value)
 		@mutex.synchronize do
 			@properties_index[value.name] = value
-			@sorted_properties = @properties_index.values.sort!
+			# ruby's sort is unstable, this trick makes it stable
+			n = 0
+			@sorted_properties = @properties_index.values.sort_by! { |it| n += 1; [it, n] }
 		end
 
 		self


### PR DESCRIPTION
@joeldrapper I'm not sure in what cases you can hit this but I did. I guess if you have lots of properties defined. But in that case `positional` arguments can change their order which brakes things. By unstable sort I mean that the sorting algorithm(it being quicksort) does not preserve the original ordering of elements that are equal to each other

update:
here's how to reproduce:
```ruby
class Example
  extend Literal::Properties
  
  10.times { |t| prop :"prop#{t}", _Any, :positional }
end

Example.literal_properties # => ❗️ @properties_index and @sorted_properties are in different order
```