### PR TITLE
Allow data structures to be used as hash keys

### DIFF
--- a/lib/literal/data_structure.rb
+++ b/lib/literal/data_structure.rb
@@ -18,6 +18,8 @@ class Literal::DataStructure
 		end
 	end
 
+	alias eql? ==
+
 	def hash
 		[self.class, to_h].hash
 	end

--- a/test/data.test.rb
+++ b/test/data.test.rb
@@ -44,3 +44,12 @@ test "can be deconstructed with keys" do
 	person = Person.new(name: "John")
 	expect(person.deconstruct_keys([:name])) == { name: "John" }
 end
+
+test "can be used as a hash key" do
+	person = Person.new(name: "John")
+	person2 = Person.new(name: "Bob")
+	hash = { person => "John", person2 => "Bob" }
+	expect(hash[person]) == "John"
+	expect(hash[person2]) == "Bob"
+	expect(hash[Person.new(name: "John")]) == "John"
+end


### PR DESCRIPTION
Need `eql?` in addition to `==`