### PR TITLE
Reapply "Ensure empty properties/datas/structs work as expected (#111)"

### DIFF
--- a/lib/literal/data_structure.rb
+++ b/lib/literal/data_structure.rb
@@ -20,6 +20,10 @@ class Literal::DataStructure
 		instance_variable_set(:"@#{key}", value)
 	end
 
+	def to_h
+		{}
+	end
+
 	def deconstruct
 		to_h.values
 	end

--- a/lib/literal/properties.rb
+++ b/lib/literal/properties.rb
@@ -6,6 +6,11 @@ module Literal::Properties
 
 	include Literal::Types
 
+	def self.extended(base)
+		super
+		base.include(base.__send__(:__literal_extension__))
+	end
+
 	def prop(name, type, kind = :keyword, reader: false, writer: false, predicate: false, default: nil, &coercion)
 		if default && !(Proc === default || default.frozen?)
 			raise Literal::ArgumentError.new("The default must be a frozen object or a Proc.")
@@ -75,6 +80,10 @@ module Literal::Properties
 			@__literal_extension__
 		else
 			@__literal_extension__ = Module.new do
+				def to_h
+						{}
+				end
+
 				set_temporary_name "Literal::Properties(Extension)" if respond_to?(:set_temporary_name)
 			end
 		end

--- a/test/data.test.rb
+++ b/test/data.test.rb
@@ -4,6 +4,9 @@ class Person < Literal::Data
 	prop :name, String
 end
 
+class Empty < Literal::Data
+end
+
 test "properties have readers by default" do
 	person = Person.new(name: "John")
 	expect(person.name) == "John"
@@ -52,4 +55,19 @@ test "can be used as a hash key" do
 	expect(hash[person]) == "John"
 	expect(hash[person2]) == "Bob"
 	expect(hash[Person.new(name: "John")]) == "John"
+end
+
+test "empty" do
+	empty = Empty.new
+	expect(empty.to_h) == {}
+
+	other = Empty.new
+	expect(empty) == other
+	expect(empty).to_eql?(other)
+	expect(empty.hash) == other.hash
+
+	other_empty = Class.new(Literal::Data).new
+	expect(empty) == other_empty
+	expect(empty).to_eql?(other_empty)
+	expect(empty.hash) != other_empty.hash
 end

--- a/test/properties.test.rb
+++ b/test/properties.test.rb
@@ -100,6 +100,14 @@ class WithNilableType
 	prop :name, Literal::Types::NilableType.new(String), :positional
 end
 
+class Empty
+	extend Literal::Properties
+end
+
+test "empty initializer" do
+	expect { Empty.new }.not_to_raise
+end
+
 test do
 	person = Person.new("John", age: 30)
 
@@ -138,6 +146,9 @@ test "properties are enumerable" do
 	props = Person.literal_properties
 	expect(props.size) == 2
 	expect(props.map(&:name)) == [:name, :age]
+
+	props = Empty.literal_properties
+	expect(props.size) == 0
 end
 
 test "introspection" do
@@ -182,6 +193,20 @@ test "after initialize callback" do
 	end
 
 	example.new(name: "John")
+
+	assert callback_called
+
+	callback_called = false
+
+	empty = Class.new do
+		extend Literal::Properties
+
+		define_method :after_initialize do
+			callback_called = true
+		end
+	end
+
+	empty.new
 
 	assert callback_called
 end
@@ -321,4 +346,12 @@ test "nested properties succeed in initializer" do
 	end.not_to_raise
 	expect { Family.new([]) }.not_to_raise
 	expect { Family.new([], last_reunion_year: 0) }.not_to_raise
+end
+
+test "#to_h" do
+		person = Person.new("John", age: 30)
+		expect(person.to_h) == { name: "John", age: 30 }
+
+		empty = Empty.new
+		expect(empty.to_h) == {}
 end


### PR DESCRIPTION
This reverts commit 797b227e1cb554a7726e8aa97c3879ea067ba6d6.

Fix was continuing to include the `include(__literal_extension__)` call on every call to `prop` ...