### PR TITLE
YARD docstring that defines initializer as forwarding all args, stops RubyMine warnings

### DIFF
--- a/lib/literal/properties.rb
+++ b/lib/literal/properties.rb
@@ -6,8 +6,13 @@ module Literal::Properties
 
 	include Literal::Types
 
+	module DocString
+		# @!method initialize(...)
+	end
+
 	def self.extended(base)
 		super
+		base.include(DocString)
 		base.include(base.__send__(:__literal_extension__))
 	end
 


### PR DESCRIPTION
If a YARD docstring is added that defines initializer as forwarding all arguments, IDEs like RubyMine maybe happier with the lack of a statically visible initialize definition