### PR TITLE
`Literal::Array#&`

### DIFF
--- a/lib/literal/array.rb
+++ b/lib/literal/array.rb
@@ -35,6 +35,13 @@ class Literal::Array
 		@__collection_type__ = collection_type
 	end
 
+	def __initialize_without_check__(value, type:, collection_type:)
+		@__type__ = type
+		@__value__ = value
+		@__collection_type__ = type
+		self
+	end
+
 	attr_reader :__type__, :__value__
 
 	def freeze
@@ -69,6 +76,25 @@ class Literal::Array
 
 		@__value__ << value
 		self
+	end
+
+	def &(other)
+		case other
+		when ::Array
+			Literal::Array.allocate.__initialize_without_check__(
+				@__value__ & other,
+				type: @__type__,
+				collection_type: @__collection_type__
+			)
+		when Literal::Array
+			Literal::Array.allocate.__initialize_without_check__(
+				@__value__ & other.__value__,
+				type: @__type__,
+				collection_type: @__collection_type__
+			)
+		else
+			raise ArgumentError.new("Cannot perform bitwise AND with #{other.class.name}.")
+		end
 	end
 
 	def push(value)

--- a/test/array.test.rb
+++ b/test/array.test.rb
@@ -68,3 +68,17 @@ test "#<< raises if the type is wrong" do
 
 	expect { array << "4" }.to_raise(Literal::TypeError)
 end
+
+test "#& performs bitwise AND with another Literal::Array" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+	other = Literal::Array(Integer).new(2, 3, 4)
+
+	expect((array & other).to_a) == [2, 3]
+end
+
+test "#& performs bitwise AND with an Array" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+	other = [2, 3, 4]
+
+	expect((array & other).to_a) == [2, 3]
+end


### PR DESCRIPTION
Add support for the bitwise AND operator on `Literal::Array`s.

See #134 