### PR TITLE
make `Literal::Array#push` accept multiple values

### DIFF
--- a/lib/literal/array.rb
+++ b/lib/literal/array.rb
@@ -190,6 +190,8 @@ class Literal::Array
 		self
 	end
 
+	alias_method :append, :push
+
 	def reject(...)
 		__with__(@__value__.reject(...))
 	end

--- a/lib/literal/array.rb
+++ b/lib/literal/array.rb
@@ -176,12 +176,17 @@ class Literal::Array
 		@__value__.pop(...)
 	end
 
-	def push(value)
-		Literal.check(actual: value, expected: @__type__) do |c|
-			c.fill_receiver(receiver: self, method: "#push")
+	def push(*value)
+		case value
+		when ::Array
+			Literal::Array(@__type__).new(*value)
+		else
+			Literal.check(actual: value, expected: @__type__) do |c|
+				c.fill_receiver(receiver: self, method: "#push")
+			end
 		end
 
-		@__value__.push(value)
+		@__value__.push(*value)
 		self
 	end
 

--- a/test/array.test.rb
+++ b/test/array.test.rb
@@ -90,3 +90,22 @@ test "#sort sorts the array" do
 	assert Literal::Array(Integer) === result
 	expect(array.sort.to_a) == [1, 2, 3]
 end
+
+test "#push appends single value" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+
+	expect((array.push(4)).to_a) == [1, 2, 3, 4]
+end
+
+test "#push appends multiple values" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+
+	expect((array.push(4, 5)).to_a) == [1, 2, 3, 4, 5]
+end
+
+test "#push raises if any type is wrong" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+
+	expect { array.push("4") }.to_raise(Literal::TypeError)
+	expect { array.push(4, "5") }.to_raise(Literal::TypeError)
+end


### PR DESCRIPTION
Related to #134 
*** 
The current implementation of `#push` was only allowing for one value to
be passed in, but if the goal is to match [ruby's functionality](https://ruby-doc.org/3.3.6/Array.html#method-i-push), then it
should accept multiple.

We also want to ensure that we perform the right type checking logic for
both scenarios.