### PR TITLE
Literal::Array: implement `#replace`, and `#insert`. add `#prepend` alias

### DIFF
--- a/lib/literal/array.rb
+++ b/lib/literal/array.rb
@@ -136,6 +136,15 @@ class Literal::Array
 		super
 	end
 
+	def insert(index, *value)
+		Literal.check(actual: value, expected: @__collection_type__) do |c|
+			c.fill_receiver(receiver: self, method: "#insert")
+		end
+
+		@__value__.insert(index, *value)
+		self
+	end
+
 	def last(...)
 		@__value__.last(...)
 	end

--- a/lib/literal/array.rb
+++ b/lib/literal/array.rb
@@ -231,4 +231,6 @@ class Literal::Array
 		@__value__.unshift(value)
 		self
 	end
+
+	alias_method :prepend, :unshift
 end

--- a/lib/literal/array.rb
+++ b/lib/literal/array.rb
@@ -205,6 +205,27 @@ class Literal::Array
 		self
 	end
 
+	def replace(value)
+		case value
+		when Array
+			Literal.check(actual: value, expected: @__collection_type__) do |c|
+				c.fill_receiver(receiver: self, method: "#replace")
+			end
+
+			@__value__.replace(value)
+		when Literal::Array(@__type__)
+			@__value__.replace(value.__value__)
+		when Literal::Array
+			raise Literal::TypeError.new(
+				context: Literal::TypeError::Context.new(expected: @__type__, actual: value.__type__)
+			)
+		else
+			raise ArgumentError.new("#replace expects Array argument")
+		end
+
+		self
+	end
+
 	def sample(...)
 		@__value__.sample(...)
 	end

--- a/test/array.test.rb
+++ b/test/array.test.rb
@@ -128,3 +128,29 @@ test "#insert raises if any type is wrong" do
 	expect { array.insert(1, "4") }.to_raise(Literal::TypeError)
 	expect { array.insert(1, 4, "5", 6) }.to_raise(Literal::TypeError)
 end
+
+test "#replace replaces with passed in array" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+
+	expect((array.replace([4, 5, 6])).to_a) == [4, 5, 6]
+end
+
+test "#replace replaces with passed in Literal::Array" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+	other = Literal::Array(Integer).new(4, 5, 6)
+
+	expect((array.replace(other)).to_a) == [4, 5, 6]
+end
+
+test "#replace raises if type of any element in array is wrong" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+
+	expect { array.replace([1, "4"]) }.to_raise(Literal::TypeError)
+	expect { array.replace(Literal::Array(String).new("4", "5")) }.to_raise(Literal::TypeError)
+end
+
+test "#replace raises with non-array argument" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+
+	expect { array.replace("not an array") }.to_raise(ArgumentError)
+end

--- a/test/array.test.rb
+++ b/test/array.test.rb
@@ -109,3 +109,22 @@ test "#push raises if any type is wrong" do
 	expect { array.push("4") }.to_raise(Literal::TypeError)
 	expect { array.push(4, "5") }.to_raise(Literal::TypeError)
 end
+
+test "#insert inserts single element at index offset" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+
+	expect((array.insert(1, 4)).to_a) == [1, 4, 2, 3]
+end
+
+test "#insert inserts multiple elements at index offset" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+
+	expect((array.insert(1, 4, 5, 6)).to_a) == [1, 4, 5, 6, 2, 3]
+end
+
+test "#insert raises if any type is wrong" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+
+	expect { array.insert(1, "4") }.to_raise(Literal::TypeError)
+	expect { array.insert(1, 4, "5", 6) }.to_raise(Literal::TypeError)
+end


### PR DESCRIPTION
Continuing to chip away at #134 
*** 
My goal was to more or less work my way down the list of "Methods for Assigning" from the ruby docs
<img width="808" alt="CleanShot 2024-11-11 at 14 20 07@2x" src="https://github.com/user-attachments/assets/93e37daa-4dda-4cd2-9c06-dc910bc8417c">

From that list, this implements:
- `#prepend` (alias for `#unshift`)
- `#insert`
- `#replace`

I'm still not 100% on if I'm always using `Literal.check` correctly. And also unsure how thorough to be in tests. Feedback welcome of course!