### PR TITLE
Initial capabilities for covariant types

### DIFF
--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -20,6 +20,7 @@ module Literal
 	autoload :Property, "literal/property"
 	autoload :Set, "literal/set"
 	autoload :Struct, "literal/struct"
+	autoload :Type, "literal/type"
 	autoload :Types, "literal/types"
 
 	# Errors

--- a/lib/literal/type.rb
+++ b/lib/literal/type.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Literal::Type
+	include Comparable
+end

--- a/lib/literal/types.rb
+++ b/lib/literal/types.rb
@@ -32,7 +32,7 @@ module Literal::Types
 	autoload :UnionType, "literal/types/union_type"
 	autoload :VoidType, "literal/types/void_type"
 
-	NilableBooleanType = NilableType.new(BooleanType)
+	NilableBooleanType = NilableType.new(BooleanType::Instance)
 	NilableCallableType = NilableType.new(CallableType)
 	NilableJSONDataType = NilableType.new(JSONDataType)
 	NilableLambdaType = NilableType.new(LambdaType)
@@ -61,7 +61,7 @@ module Literal::Types
 
 	# Matches if the value is `true` or `false`.
 	def _Boolean
-		BooleanType
+		BooleanType::Instance
 	end
 
 	# Nilable version of `_Boolean`

--- a/lib/literal/types/boolean_type.rb
+++ b/lib/literal/types/boolean_type.rb
@@ -1,11 +1,26 @@
 # frozen_string_literal: true
 
 # @api private
-module Literal::Types::BooleanType
-	def self.inspect = "_Boolean"
+class Literal::Types::BooleanType
+	include Literal::Type
 
-	def self.===(value)
+	Instance = new
+
+	def inspect = "_Boolean"
+
+	def ===(value)
 		true == value || false == value
+	end
+
+	def <=>(other)
+		case other
+		when true, false
+			1
+		when Literal::Types::BooleanType
+			0
+		else
+			-1
+		end
 	end
 
 	freeze

--- a/test/types.test.rb
+++ b/test/types.test.rb
@@ -30,6 +30,11 @@ test "_Boolean" do
 	assert _Boolean === false
 
 	refute _Boolean === nil
+
+	assert _Boolean > true
+	assert _Boolean > false
+	refute _Boolean > nil
+	assert _Boolean == _Boolean
 end
 
 test "_Callable" do


### PR DESCRIPTION
In order to avoid type checks on some Literal::Array, Literal::Hash and Literal::Set operations, we will need to be able to establish if one type is a subtype of another type.

We can already do this with Modules, using `<`, `==`, and `>`. I think we should be able to do it for Literal types too. For example, `true` and `false` are sub types of `_Boolean`.

If you’re merging a `Literal::Array(true)` into a `Literal::Array(_Boolean)`, you should not have to check its types.