### PR TITLE
Fix typo in .__with__ method

### DIFF
--- a/lib/literal/array.rb
+++ b/lib/literal/array.rb
@@ -38,7 +38,7 @@ class Literal::Array
 	def __initialize_without_check__(value, type:, collection_type:)
 		@__type__ = type
 		@__value__ = value
-		@__collection_type__ = type
+		@__collection_type__ = collection_type
 		self
 	end
 


### PR DESCRIPTION
Small typo: when calling `.__with__`, the returning object would have the `__collection_type__` set to the `__type__`.