### PR TITLE
Implement `Literal::Array#values_at`

### DIFF
--- a/lib/literal/array.rb
+++ b/lib/literal/array.rb
@@ -303,4 +303,28 @@ class Literal::Array
 	end
 
 	alias_method :prepend, :unshift
+
+	def values_at(*indexes)
+		unless @__type__ === nil
+			max_value = length - 1
+			min_value = -length
+
+			indexes.each do |index|
+				case index
+				when Integer
+					if index < min_value || index > max_value
+						raise IndexError.new("index #{index} out of range")
+					end
+				when Range
+					if index.begin < min_value || index.end > max_value
+						raise IndexError.new("index #{index} out of range")
+					end
+				end
+			end
+		end
+
+		__with__(
+			@__value__.values_at(*indexes)
+		)
+	end
 end

--- a/test/array.test.rb
+++ b/test/array.test.rb
@@ -201,3 +201,22 @@ test "#replace raises with non-array argument" do
 
 	expect { array.replace("not an array") }.to_raise(ArgumentError)
 end
+
+test "#values_at returns the values at the given indexes" do
+	array = Literal::Array(Integer).new(1, 2, 3)
+
+	expect(array.values_at(0).to_a) == [1]
+	expect(array.values_at(1).to_a) == [2]
+	expect(array.values_at(2).to_a) == [3]
+	expect(array.values_at(1..2).to_a) == [2, 3]
+
+	expect { array.values_at(3) }.to_raise(IndexError)
+	expect { array.values_at(-4) }.to_raise(IndexError)
+	expect { array.values_at(-4..2) }.to_raise(IndexError)
+	expect { array.values_at(1..3) }.to_raise(IndexError)
+
+	nilable_array = Literal::Array(_Nilable(Integer)).new(1, 2, 3)
+
+	expect(nilable_array.values_at(-4).to_a) == [nil]
+	expect(nilable_array.values_at(3).to_a) == [nil]
+end


### PR DESCRIPTION
If the type is nilable, it works as normal but returns a `Literal::Array(T)`. However, if the type is not nilable, it will raise an error if you try to select values that are out of range.

Closes #215 