### PR TITLE
Add aliases for `Literal::Array#collect` and `#collect!`

### DIFF
--- a/lib/literal/array.rb
+++ b/lib/literal/array.rb
@@ -274,12 +274,16 @@ class Literal::Array
 		end
 	end
 
+	alias_method :collect, :map
+
 	# TODO: we can make this faster
 	def map!(&)
 		new_array = map(@__type__, &)
 		@__value__ = new_array.__value__
 		self
 	end
+
+	alias_method :collect!, :map!
 
 	def max(n = nil, &)
 		if n


### PR DESCRIPTION
`Array` has aliases `#map -> #collect`  and `#map! -> #collect!`

This change add `Literal::Array` aliases `#collect -> #map` and `#collect! -> #map!`. 

While it wouldn't change the functionality, it may be worth switching the alias and the target to match the ruby implementation. 