### PR TITLE
Fix data property dup

### DIFF
--- a/lib/literal/data_property.rb
+++ b/lib/literal/data_property.rb
@@ -11,6 +11,6 @@ class Literal::DataProperty < Literal::Property
 			escaped_name <<
 			" : " <<
 			escaped_name <<
-			".dup.freeze\n"
+			".freeze\n"
 	end
 end

--- a/test/data.test.rb
+++ b/test/data.test.rb
@@ -17,6 +17,13 @@ test "data objects are frozen" do
 	expect(person).to_be(:frozen?)
 end
 
+test "mutable attributes are duplicated and frozen" do
+	name = +"John"
+	person = Person.new(name:)
+
+	expect(person.name).to_be(:frozen?)
+end
+
 test "immutable attributes are not duplicated" do
 	name = "John"
 	person = Person.new(name:)

--- a/test/data.test.rb
+++ b/test/data.test.rb
@@ -17,14 +17,6 @@ test "data objects are frozen" do
 	expect(person).to_be(:frozen?)
 end
 
-test "mutable attributes are duplicated and frozen" do
-	name = +"John"
-	person = Person.new(name:)
-
-	expect(person.name).to_be(:frozen?)
-	expect(person.name).not_to_equal?(name)
-end
-
 test "immutable attributes are not duplicated" do
 	name = "John"
 	person = Person.new(name:)


### PR DESCRIPTION
When `dup`ing  a property we can lose some attributes. So e.g.:
```ruby
class Ex < Literal::Data
  prop :record, Book
end

record = Book.find(1)
ex = Ex.new(record:)
ex.record # => <Book id: nil>
```
because rails's dup does not preserve ids(and some other things)

cc @joeldrapper 