### PR TITLE
Literal::Enum.to_h should yield members, not values

### DIFF
--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -158,8 +158,12 @@ class Literal::Enum
 			method(:coerce).to_proc
 		end
 
-		def to_h(...)
-			@values.to_h(...)
+		def to_h(&)
+			if block_given?
+				@members.to_h(&)
+			else
+				@members.to_h { |it| [it, it.value] }
+			end
 		end
 	end
 

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -47,7 +47,7 @@ test do
 	expect(Color.coerce(1)) == Color::Red
 	expect(Color.coerce(Color::Red)) == Color::Red
 	expect(Color.to_set) == Set[Color::Red, Color::Green, Color::Blue]
-	expect(Color.to_h) == { 1 => Color::Red, 2 => Color::Green, 3 => Color::Blue }
+	expect(Color.to_h) == { Color::Red => 1, Color::Green => 2, Color::Blue => 3 }
 	expect(Color.to_a) == [Color::Red, Color::Green, Color::Blue] if RUBY_VERSION >= "3.2"
 	expect(Color.values) == [1, 2, 3] if RUBY_VERSION >= "3.2"
 	expect([3, 2, 1].map(&Color)) == [Color::Blue, Color::Green, Color::Red]


### PR DESCRIPTION
If `Literal::Enum.to_h` yields members, it will be much easier to construct your own `to_h` blocks using `it`. Additionally, the default `to_h` now maps members to values. Previously, this was the other way around.