### PR TITLE
Remove the option to disable checks

### DIFF
--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module Literal
-	TYPE_CHECKS_DISABLED = ENV["LITERAL_TYPE_CHECKS"] == "false"
-
 	autoload :Array, "literal/array"
 	autoload :Data, "literal/data"
 	autoload :DataProperty, "literal/data_property"

--- a/lib/literal/property.rb
+++ b/lib/literal/property.rb
@@ -118,29 +118,18 @@ class Literal::Property
 			"\n  value\nend\n"
 	end
 
-	if Literal::TYPE_CHECKS_DISABLED
-		def generate_writer_method(buffer = +"")
-			buffer <<
-				(@writer ? @writer.name : "public") <<
-				" def " <<
-				@name.name <<
-				"=(value)\n" <<
-				"  @#{@name.name} = value\nend\n"
-		end
-	else # type checks are enabled
-		def generate_writer_method(buffer = +"")
-			buffer <<
-				(@writer ? @writer.name : "public") <<
-				" def " <<
-				@name.name <<
-				"=(value)\n" <<
-				"  self.class.literal_properties[:" <<
-				@name.name <<
-				"].check_writer(self, value)\n" <<
-				"  @" << @name.name << " = value\n" <<
-				"rescue Literal::TypeError => error\n  error.set_backtrace(caller(1))\n  raise\n" <<
-				"end\n"
-		end
+	def generate_writer_method(buffer = +"")
+		buffer <<
+			(@writer ? @writer.name : "public") <<
+			" def " <<
+			@name.name <<
+			"=(value)\n" <<
+			"  self.class.literal_properties[:" <<
+			@name.name <<
+			"].check_writer(self, value)\n" <<
+			"  @" << @name.name << " = value\n" <<
+			"rescue Literal::TypeError => error\n  error.set_backtrace(caller(1))\n  raise\n" <<
+			"end\n"
 	end
 
 	def generate_predicate_method(buffer = +"")
@@ -171,10 +160,7 @@ class Literal::Property
 			generate_initializer_coerce_property(buffer)
 		end
 
-		unless Literal::TYPE_CHECKS_DISABLED
-			generate_initializer_check_type(buffer)
-		end
-
+		generate_initializer_check_type(buffer)
 		generate_initializer_assign_value(buffer)
 	end
 


### PR DESCRIPTION
Maintaining and testing this option is very difficult, and the type checks are so fast it’s not necessary. Also, this was never part of the public API so it should be safe to remove.