### PR TITLE
Allow enum coercion from symbol

### DIFF
--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -149,6 +149,12 @@ class Literal::Enum
 			case value
 			when self
 				value
+			when Symbol
+				begin
+					const_get(value)
+				rescue NameError
+					nil
+				end
 			else
 				self[value]
 			end

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -150,7 +150,7 @@ class Literal::Enum
 			when self
 				value
 			when Symbol
-				begin
+				self[value] || begin
 					const_get(value)
 				rescue NameError
 					nil

--- a/lib/literal/rails/enum_type.rb
+++ b/lib/literal/rails/enum_type.rb
@@ -7,29 +7,13 @@ class Literal::Rails::EnumType < ActiveModel::Type::Value
 	end
 
 	def cast(value)
-		case value
-		when @enum
-			value
-		else
-			deserialize(value)
-		end
+		@enum.coerce(value)
 	end
 
 	def serialize(value)
-		case value
-		when nil
-			nil
-		when @enum
-			value.value
-		else
-			if @enum[value]
-				value
-			else
-				raise Literal::ArgumentError.new(
-					"Invalid value: #{value.inspect}. Expected an #{@enum.inspect}.",
-				)
-			end
-		end
+		@enum.coerce(value).value || raise(
+			Literal::ArgumentError.new("Invalid value: #{value.inspect}. Expected an #{@enum.inspect}.")
+		)
 	end
 
 	def deserialize(value)
@@ -38,7 +22,7 @@ class Literal::Rails::EnumType < ActiveModel::Type::Value
 			nil
 		else
 			@enum[value] || raise(
-				ArgumentError.new("Invalid value: #{value.inspect} for #{@enum}"),
+				ArgumentError.new("Invalid value: #{value.inspect} for #{@enum}")
 			)
 		end
 	end

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -30,6 +30,11 @@ class Switch < Literal::Enum(_Boolean)
 	__after_defined__ if RUBY_ENGINE == "truffleruby"
 end
 
+class SymbolTypedEnum < Literal::Enum(Symbol)
+	A = new(:B)
+	B = new(:A)
+end
+
 test ".coerce from value" do
 	assert_equal Color.coerce(1), Color::Red
 end
@@ -60,6 +65,10 @@ end
 
 test ".cast returns nil if the member can't be found" do
 	assert_equal Color.cast(10), nil
+end
+
+test ".cast goes with the value when there are conflicts with the keys" do
+	assert_equal SymbolTypedEnum.coerce(:A), SymbolTypedEnum::B
 end
 
 test ".to_set" do

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -30,30 +30,105 @@ class Switch < Literal::Enum(_Boolean)
 	__after_defined__ if RUBY_ENGINE == "truffleruby"
 end
 
+test ".coerce from value" do
+	assert_equal Color.coerce(1), Color::Red
+end
+
+test ".coerce from enum" do
+	assert_equal Color.coerce(Color::Red), Color::Red
+end
+
+test ".coerce from symbol" do
+	assert_equal Color.coerce(:Red), Color::Red
+end
+
+test ".coerce with invalid symbol returns nil" do
+	assert_equal Color.coerce(:Invalid), nil
+end
+
+test ".[] looks up the key by value" do
+	assert_equal Color[1], Color::Red
+end
+
+test ".[] returns nil if the member can't be found" do
+	assert_equal Color[10], nil
+end
+
+test ".cast looks up the key by value" do
+	assert_equal Color.cast(1), Color::Red
+end
+
+test ".cast returns nil if the member can't be found" do
+	assert_equal Color.cast(10), nil
+end
+
+test ".to_set" do
+	assert_equal Color.to_set, Set[
+		Color::Red,
+		Color::Green,
+		Color::Blue
+	]
+end
+
+test ".to_h without block" do
+	assert_equal Color.to_h, {
+		Color::Red => 1,
+		Color::Green => 2,
+		Color::Blue => 3,
+	}
+end
+
+test ".to_proc coerces" do
+	assert_equal [1, :Green, Color::Blue].map(&Color), [
+		Color::Red,
+		Color::Green,
+		Color::Blue,
+	]
+end
+
+test "#where" do
+	assert_equal [Color::Red], Color.where(hex: "#FF0000")
+end
+
+test "#find_by" do
+	assert_equal Color::Red, Color.find_by(hex: "#FF0000")
+end
+
+test "#find_by raises when used with a non-unique index" do
+	error = assert_raises(ArgumentError) { Color.find_by(lower_hex: "#ff0000") }
+	assert_equal error.message, "You can only use `find_by` on unique indexes."
+end
+
+test "#value returns the value" do
+	assert_equal Color::Red.value, 1
+end
+
+test "reading property readers" do
+	assert_equal Color::Red.hex, "#FF0000"
+end
+
+test "generated predicates" do
+	assert_equal Color::Red.red?, true
+	assert_equal Color::Red.green?, false
+	assert_equal Color::Red.blue?, false
+end
+
+test "members are frozen" do
+	assert Color::Red.frozen?
+end
+
+test "classes are frozen" do
+	assert Color.frozen?
+end
+
+test "singleton methods" do
+	assert_equal Switch::Off.toggle, Switch::On
+	assert_equal Switch::On.toggle, Switch::Off
+end
+
 test do
-	assert_equal([Color::Red], Color.where(hex: "#FF0000"))
-	assert_equal(Color::Red, Color.find_by(hex: "#FF0000"))
-	assert_raises(ArgumentError) { Color.find_by(lower_hex: "#ff0000") }
-	assert_equal([Color::Red], Color.where(lower_hex: "#ff0000"))
-	assert_equal(1, Color::Red.value)
-	assert_equal("#FF0000", Color::Red.hex)
-	assert_equal(true, Color::Red.red?)
-	assert_equal(false, Color::Red.green?)
-	assert_equal(true, Color.frozen?)
-	assert_equal(true, Color::Red.frozen?)
-	assert_equal(Color::Red, Color[1])
-	assert_equal(Color::Red, Color.cast(1))
-	assert_equal(Color::Red, Color.coerce(1))
-	assert_equal(Color::Red, Color.coerce(Color::Red))
-	assert_equal(Set[Color::Red, Color::Green, Color::Blue], Color.to_set)
-	assert_equal({ Color::Red => 1, Color::Green => 2, Color::Blue => 3 }, Color.to_h)
-	assert_equal([Color::Red, Color::Green, Color::Blue], Color.to_a) if RUBY_VERSION >= "3.2"
-	assert_equal([1, 2, 3], Color.values) if RUBY_VERSION >= "3.2"
 	assert_equal([Color::Blue, Color::Green, Color::Red], [3, 2, 1].map(&Color))
 	assert_equal([Color::Red, Color::Green], [Color::Red, 2].map(&Color))
-
-	assert_equal(Switch::On, Switch::Off.toggle)
-	assert_equal(Switch::Off, Switch::On.toggle)
 end
 
 test "pattern matching" do


### PR DESCRIPTION
This PR makes it possible to coerce enums from their constant name as a symbol.

```ruby
class Color < Literal::Enum(Integer)
  Red = new(1)
  Green = new(2)
  Blue = new(3)
end

Color.coerce(:Red) # => Color::Red
```

Since `.to_proc` maps to coerce, this means you can use it as a literal property coercion.

```ruby
class MyThing
  prop :color, Color, &Color
end

MyThing.new(color: :Red)
```

This is useful if the property itself already has the context of the enum.