### PR TITLE
Literal::Array(Literal::Tuple)#transpose

### DIFF
--- a/lib/literal/array.rb
+++ b/lib/literal/array.rb
@@ -530,6 +530,24 @@ class Literal::Array
 		__with__(@__value__.take(...))
 	end
 
+	def transpose
+		case @__type__
+		when Literal::Tuple::Generic
+			tuple_types = @__type__.types
+			new_array_types = tuple_types.map { |t| Literal::Array(t) }
+
+			Literal::Tuple(*new_array_types).new(
+				*new_array_types.each_with_index.map do |t, i|
+					t.new(
+						*@__value__.map { |it| it[i] }
+					)
+				end
+			)
+		else
+			raise ArgumentError.new("Not implemented")
+		end
+	end
+
 	def to_a
 		@__value__.dup
 	end

--- a/lib/literal/tuple.rb
+++ b/lib/literal/tuple.rb
@@ -56,9 +56,17 @@ class Literal::Tuple
 		@__types__ = types
 	end
 
+	def inspect
+		@__values__.inspect
+	end
+
 	attr_reader :__values__, :__types__
 
 	def ==(other)
-		Literal::Tuple === other && @__values__ == other.__values__
+		(Literal::Tuple === other) && (@__values__ == other.__values__)
+	end
+
+	def [](index)
+		@__values__[index]
 	end
 end

--- a/test/array.test.rb
+++ b/test/array.test.rb
@@ -759,3 +759,22 @@ test "#product with another Literal::Array" do
 	assert_equal result.size, 4
 	assert_equal result.first, Literal::Tuple(Integer, String).new(1, "a")
 end
+
+test "#transpose with a nested literal tuple" do
+	array = Literal::Array(Literal::Tuple(Integer, String)).new(
+		Literal::Tuple(Integer, String).new(1, "a"),
+		Literal::Tuple(Integer, String).new(2, "b"),
+	)
+
+	transposed = array.transpose
+
+	expected = Literal::Tuple(
+		Literal::Array(Integer),
+		Literal::Array(String)
+	).new(
+		Literal::Array(Integer).new(1, 2),
+		Literal::Array(String).new("a", "b"),
+	)
+
+	assert_equal transposed, expected
+end

--- a/test/array.test.rb
+++ b/test/array.test.rb
@@ -766,15 +766,11 @@ test "#transpose with a nested literal tuple" do
 		Literal::Tuple(Integer, String).new(2, "b"),
 	)
 
-	transposed = array.transpose
-
-	expected = Literal::Tuple(
+	assert_equal array.transpose, Literal::Tuple(
 		Literal::Array(Integer),
 		Literal::Array(String)
 	).new(
 		Literal::Array(Integer).new(1, 2),
 		Literal::Array(String).new("a", "b"),
 	)
-
-	assert_equal transposed, expected
 end

--- a/test/array.test.rb
+++ b/test/array.test.rb
@@ -768,7 +768,7 @@ test "#transpose with a nested literal tuple" do
 
 	assert_equal array.transpose, Literal::Tuple(
 		Literal::Array(Integer),
-		Literal::Array(String)
+		Literal::Array(String),
 	).new(
 		Literal::Array(Integer).new(1, 2),
 		Literal::Array(String).new("a", "b"),


### PR DESCRIPTION
This allows us to transpose a `Literal::Array(Literal::Tuple)` to a new tuple of arrays of the correct type.