### PR TITLE
Make enums ordered

### DIFF
--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -31,7 +31,7 @@ module Literal
 
 	def self.Enum(type)
 		Class.new(Literal::Enum) do
-			prop :value, type, :positional
+			prop :value, type, :positional, reader: :public
 		end
 	end
 

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -99,7 +99,7 @@ class Literal::Enum
 		def new(*args, **kwargs, &block)
 			raise ArgumentError if frozen?
 			new_object = super(*args, **kwargs, &nil)
-			new_object.instance_variable_set(:@__position__, @members.size)
+			new_object.instance_variable_set(:@__position__, @members.length)
 
 			new_object.instance_exec(&block) if block
 

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -33,7 +33,7 @@ class Literal::Enum
 		end
 
 		def index_of(member)
-			member.__index__
+			coerce(member).__index__
 		end
 
 		def at_index(n)

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -32,11 +32,11 @@ class Literal::Enum
 			end
 		end
 
-		def index_of(member)
-			coerce(member).__index__
+		def position_of(member)
+			coerce(member).__position__
 		end
 
-		def at_index(n)
+		def at_position(n)
 			@members[n]
 		end
 
@@ -99,7 +99,7 @@ class Literal::Enum
 		def new(*args, **kwargs, &block)
 			raise ArgumentError if frozen?
 			new_object = super(*args, **kwargs, &nil)
-			new_object.instance_variable_set(:@__index__, @members.size)
+			new_object.instance_variable_set(:@__position__, @members.size)
 
 			new_object.instance_exec(&block) if block
 
@@ -209,23 +209,23 @@ class Literal::Enum
 	def <=>(other)
 		case other
 		when self.class
-			@__index__ <=> other.__index__
+			@__position__ <=> other.__position__
 		else
 			raise ArgumentError.new("Can't compare instances of #{other.class} to instances of #{self.class}")
 		end
 	end
 
 	def succ
-		self.class.members[@__index__ + 1]
+		self.class.members[@__position__ + 1]
 	end
 
 	def pred
-		if @__index__ <= 0
+		if @__position__ <= 0
 			nil
 		else
-			self.class.members[@__index__ - 1]
+			self.class.members[@__position__ - 1]
 		end
 	end
 
-	attr_reader :__index__
+	attr_reader :__position__
 end

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -79,10 +79,22 @@ test ".cast goes with the value when there are conflicts with the keys" do
 	assert_equal SymbolTypedEnum.coerce(:A), SymbolTypedEnum::B
 end
 
-test ".index_of" do
+test ".index_of with member" do
 	assert_equal Color.index_of(Color::Red), 0
 	assert_equal Color.index_of(Color::Green), 1
 	assert_equal Color.index_of(Color::Blue), 2
+end
+
+test ".index_of with name" do
+	assert_equal Color.index_of(:Red), 0
+	assert_equal Color.index_of(:Green), 1
+	assert_equal Color.index_of(:Blue), 2
+end
+
+test ".index_of with value" do
+	assert_equal Color.index_of(1), 0
+	assert_equal Color.index_of(2), 1
+	assert_equal Color.index_of(3), 2
 end
 
 test ".at_index" do

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -79,6 +79,18 @@ test ".cast goes with the value when there are conflicts with the keys" do
 	assert_equal SymbolTypedEnum.coerce(:A), SymbolTypedEnum::B
 end
 
+test ".index_of" do
+	assert_equal Color.index_of(Color::Red), 0
+	assert_equal Color.index_of(Color::Green), 1
+	assert_equal Color.index_of(Color::Blue), 2
+end
+
+test ".at_index" do
+	assert_equal Color.at_index(0), Color::Red
+	assert_equal Color.at_index(1), Color::Green
+	assert_equal Color.at_index(2), Color::Blue
+end
+
 test ".to_set" do
 	assert_equal Color.to_set, Set[
 		Color::Red,
@@ -101,6 +113,32 @@ test ".to_proc coerces" do
 		Color::Green,
 		Color::Blue,
 	]
+end
+
+test "#succ" do
+	assert_equal Color::Red.succ, Color::Green
+	assert_equal Color::Green.succ, Color::Blue
+	assert_equal Color::Blue.succ, nil
+end
+
+test "#pred" do
+	assert_equal Color::Red.pred, nil
+	assert_equal Color::Green.pred, Color::Red
+	assert_equal Color::Blue.pred, Color::Green
+end
+
+test "#<=>" do
+	assert_equal Color::Red <=> Color::Green, -1
+	assert_equal Color::Red <=> Color::Red, 0
+	assert_equal Color::Green <=> Color::Red, 1
+end
+
+test "enums are rangeable" do
+	range = (Color::Red..Color::Green)
+
+	assert Range === range
+	assert_equal Color::Red, range.begin
+	assert_equal Color::Green, range.end
 end
 
 test "#where" do

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -79,28 +79,28 @@ test ".cast goes with the value when there are conflicts with the keys" do
 	assert_equal SymbolTypedEnum.coerce(:A), SymbolTypedEnum::B
 end
 
-test ".index_of with member" do
-	assert_equal Color.index_of(Color::Red), 0
-	assert_equal Color.index_of(Color::Green), 1
-	assert_equal Color.index_of(Color::Blue), 2
+test ".position_of with member" do
+	assert_equal Color.position_of(Color::Red), 0
+	assert_equal Color.position_of(Color::Green), 1
+	assert_equal Color.position_of(Color::Blue), 2
 end
 
-test ".index_of with name" do
-	assert_equal Color.index_of(:Red), 0
-	assert_equal Color.index_of(:Green), 1
-	assert_equal Color.index_of(:Blue), 2
+test ".position_of with name" do
+	assert_equal Color.position_of(:Red), 0
+	assert_equal Color.position_of(:Green), 1
+	assert_equal Color.position_of(:Blue), 2
 end
 
-test ".index_of with value" do
-	assert_equal Color.index_of(1), 0
-	assert_equal Color.index_of(2), 1
-	assert_equal Color.index_of(3), 2
+test ".position_of with value" do
+	assert_equal Color.position_of(1), 0
+	assert_equal Color.position_of(2), 1
+	assert_equal Color.position_of(3), 2
 end
 
-test ".at_index" do
-	assert_equal Color.at_index(0), Color::Red
-	assert_equal Color.at_index(1), Color::Green
-	assert_equal Color.at_index(2), Color::Blue
+test ".at_position" do
+	assert_equal Color.at_position(0), Color::Red
+	assert_equal Color.at_position(1), Color::Green
+	assert_equal Color.at_position(2), Color::Blue
 end
 
 test ".to_set" do

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -145,6 +145,10 @@ test "#<=>" do
 	assert_equal Color::Green <=> Color::Red, 1
 end
 
+test "#name" do
+	assert Color::Red.name.end_with?("Color::Red")
+end
+
 test "enums are rangeable" do
 	range = (Color::Red..Color::Green)
 


### PR DESCRIPTION
Enums are now by default ordered by their definition order, which means they are now range-able.