### PR TITLE
Fix error when using non-ActiveRecord::Base on ActiveRecord::Relation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ group :development do
 	gem "rubocop", platform: :ruby
 	gem "ruby-lsp", platform: :ruby
 	gem "simplecov", platform: :ruby
+	gem "rails", platform: :ruby
 end

--- a/config/quickdraw.rb
+++ b/config/quickdraw.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_record/railtie"
 require "literal"
 require "securerandom"
 require "set"

--- a/lib/literal/rails/patches/active_record.rb
+++ b/lib/literal/rails/patches/active_record.rb
@@ -4,9 +4,10 @@ module ActiveRecord
 	class RelationType
 		def initialize(model_class)
 			unless Class === model_class && model_class < ActiveRecord::Base
-				raise Literal::TypeError.expected(
-					model_class,
-					to_be_a: ActiveRecord::Base,
+				raise Literal::TypeError.new(
+					context: Literal::TypeError::Context.new(
+						expected: ActiveRecord::Base, actual: model_class
+					)
 				)
 			end
 

--- a/test/rails.test.rb
+++ b/test/rails.test.rb
@@ -1,0 +1,9 @@
+test "ActiveRecord::Relation with non-ActiveRecord::Base child" do
+		assert_raises(Literal::TypeError) do
+				Class.new do
+						extend Literal::Properties
+
+						prop :example, ActiveRecord::Relation(String)
+				end
+		end
+end


### PR DESCRIPTION
It seems like a wrong way to build Literal::TypeError

```
NoMethodError (undefined method 'expected' for class Literal::TypeError):

literal (1.4.0) lib/literal/rails/patches/active_record.rb:7:in 'ActiveRecord::RelationType#initialize'
literal (1.4.0) lib/literal/rails/patches/active_record.rb:29:in 'Class#new'
literal (1.4.0) lib/literal/rails/patches/active_record.rb:29:in 'ActiveRecord.Relation'
```