### PR TITLE
Fixing Rubocop and JRuby CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,10 @@ gemspec
 
 gem "quickdraw", git: "https://github.com/joeldrapper/quickdraw.git"
 gem "benchmark-ips"
+gem "rails"
 
 group :development do
 	gem "rubocop", platform: :ruby
 	gem "ruby-lsp", platform: :ruby
 	gem "simplecov", platform: :ruby
-	gem "rails", platform: :ruby
 end

--- a/test/rails.test.rb
+++ b/test/rails.test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 test "ActiveRecord::Relation with non-ActiveRecord::Base child" do
 		assert_raises(Literal::TypeError) do
 				Class.new do


### PR DESCRIPTION
My last PR broke CI:
- JRuby tests were broken because Rails was added as `platform: ruby` dependency
- Rubocop was complaining about missing frozen string literal comment.

Sorry.