### PR TITLE
Fix data structure `==` equality

### DIFF
--- a/lib/literal/properties/schema.rb
+++ b/lib/literal/properties/schema.rb
@@ -102,7 +102,7 @@ class Literal::Properties::Schema
 		i, n = 0, sorted_properties.size
 		while i < n
 			property = sorted_properties[i]
-			buffer << "  @" << property.name.name << " == other." << property.name.name
+			buffer << "  @#{property.name.name} == other.instance_variable_get(:@#{property.name.name})"
 			buffer << " &&\n  " if i < n - 1
 			i += 1
 		end

--- a/test/data.test.rb
+++ b/test/data.test.rb
@@ -6,6 +6,20 @@ end
 
 class Empty < Literal::Data
 end
+
+class ReaderlessExample < Literal::Data
+	prop :name, String, reader: false
+end
+
+test "== comparison with readerless properties" do
+	a = ReaderlessExample.new(name: "John")
+	b = ReaderlessExample.new(name: "John")
+	c = ReaderlessExample.new(name: "Bob")
+
+	assert_equal(a, b)
+	refute_equal(a, c)
+end
+
 test "properties have readers by default" do
 	person = Person.new(name: "John")
 	assert_equal(person.name, "John")


### PR DESCRIPTION
The generated `==` methods on data structures were assuming each property had a reader, which is not necessary the case. It is possible to disable readers for properties.