### PR TITLE
Cache frozen array checks

### DIFF
--- a/lib/literal/types/array_type.rb
+++ b/lib/literal/types/array_type.rb
@@ -21,12 +21,14 @@ class Literal::Types::ArrayType
 		return false unless Array === value
 
 		if value.frozen?
-			if CACHE[value]
+			cache = CACHE[@type] ||= WeakMap.new
+
+			if cache[value]
 				true
 			elsif value.all?(@type)
-				CACHE[value] = true
+				cache[value] = true
 			else
-				CACHE[value] = false
+				cache[value] = false
 			end
 		else
 			value.all?(@type)

--- a/lib/literal/types/array_type.rb
+++ b/lib/literal/types/array_type.rb
@@ -2,6 +2,8 @@
 
 # @api private
 class Literal::Types::ArrayType
+	CACHE = ObjectSpace::WeakMap.new
+
 	include Literal::Type
 
 	def initialize(type)
@@ -16,7 +18,19 @@ class Literal::Types::ArrayType
 	end
 
 	def ===(value)
-		Array === value && value.all?(@type)
+		return false unless Array === value
+
+		if value.frozen?
+			if CACHE[value]
+				true
+			elsif value.all?(@type)
+				CACHE[value] = true
+			else
+				CACHE[value] = false
+			end
+		else
+			value.all?(@type)
+		end
 	end
 
 	def >=(other)


### PR DESCRIPTION
Probably not going to merge this, but I wanted to explore the idea of caching type checks for frozen arrays. Once we’ve checked a frozen array against an _Array generic, we shouldn’t need to check it again.

Note: the performance issue this solves (performing `O(n)` checks more than once for the same object) is also solved by the upcoming `Literal::Array` objects.