### PR TITLE
Value objects

### DIFF
--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -11,8 +11,33 @@ module Literal
 
 		loader.collapse("#{__dir__}/literal/flags")
 		loader.collapse("#{__dir__}/literal/errors")
-
 		loader.setup
+	end
+
+	def self.Value(*, **, &block)
+		value_class = Class.new(Literal::Value)
+
+		type = Literal::Types._Constraint(*, **)
+		value_class.define_method(:type) { type }
+
+		if subtype?(type, of: Integer)
+			value_class.alias_method :to_i, :value
+		elsif subtype?(type, of: String)
+			value_class.alias_method :to_s, :value
+			value_class.alias_method :to_str, :value
+		elsif subtype?(type, of: Array)
+			value_class.alias_method :to_a, :value
+			value_class.alias_method :to_ary, :value
+		elsif subtype?(type, of: Hash)
+			value_class.alias_method :to_h, :value
+		elsif subtype?(type, of: Float)
+			value_class.alias_method :to_f, :value
+		elsif subtype?(type, of: Set)
+			value_class.alias_method :to_set, :value
+		end
+
+		value_class.class_eval(&block) if block
+		value_class.freeze
 	end
 
 	def self.Enum(type)

--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -40,6 +40,16 @@ module Literal
 		value_class.freeze
 	end
 
+	def self.Delegator(*args, **kwargs, &block)
+		delegator_class = Class.new(Literal::Delegator)
+
+		type = Literal::Types._Constraint(*args, **kwargs)
+		delegator_class.define_method(:__type__) { type }
+
+		delegator_class.class_eval(&block) if block
+		delegator_class.freeze
+	end
+
 	def self.Enum(type)
 		Class.new(Literal::Enum) do
 			prop :value, type, :positional, reader: :public

--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -14,10 +14,10 @@ module Literal
 		loader.setup
 	end
 
-	def self.Value(*, **, &block)
+	def self.Value(*args, **kwargs, &block)
 		value_class = Class.new(Literal::Value)
 
-		type = Literal::Types._Constraint(*, **)
+		type = Literal::Types._Constraint(*args, **kwargs)
 		value_class.define_method(:type) { type }
 
 		if subtype?(type, of: Integer)

--- a/lib/literal/delegator.rb
+++ b/lib/literal/delegator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Literal::Delegator < SimpleDelegator
+	def self.to_proc
+		-> (value) { new(value) }
+	end
+
+	def self.[](value)
+		new(value)
+	end
+
+	def initialize(value)
+		Literal.check(expected: __type__, actual: value)
+		super
+		freeze
+	end
+
+	def ===(other)
+		self.class === other && __getobj__ == other.__getobj__
+	end
+
+	alias_method :==, :===
+
+	freeze
+end

--- a/lib/literal/value.rb
+++ b/lib/literal/value.rb
@@ -5,6 +5,10 @@ class Literal::Value
 		-> (value) { new(value) }
 	end
 
+	def self.[](value)
+		new(value)
+	end
+
 	def self.delegate(*methods)
 		methods.each do |method_name|
 			class_eval(<<~RUBY, __FILE__, __LINE__ + 1)

--- a/lib/literal/value.rb
+++ b/lib/literal/value.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Literal::Value
+	def self.to_proc
+		-> (value) { new(value) }
+	end
+
+	def self.delegate(*methods)
+		methods.each do |method_name|
+			class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+				# frozen_string_literal: true
+
+				def #{method_name}(...)
+					@value.#{method_name}(...)
+				end
+			RUBY
+		end
+	end
+
+	def initialize(value)
+		Literal.check(expected: type, actual: value)
+		@value = value
+		freeze
+	end
+
+	attr_reader :value
+
+	def inspect
+		"#{self.class.name}(#{value.inspect})"
+	end
+end

--- a/lib/literal/value.rb
+++ b/lib/literal/value.rb
@@ -32,4 +32,12 @@ class Literal::Value
 	def inspect
 		"#{self.class.name}(#{value.inspect})"
 	end
+
+	def ===(other)
+		self.class === other && @value == other.value
+	end
+
+	alias_method :==, :===
+
+	freeze
 end

--- a/test/delegator.test.rb
+++ b/test/delegator.test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+UserID = Literal::Delegator(String) do
+	def double = length * 2
+end
+
+test ".===" do
+	user_id = UserID.new("123")
+	assert UserID === user_id
+end
+
+test ".[]" do
+	user_id = UserID["123"]
+	assert UserID === user_id
+end
+
+test "custom methods" do
+	user_id = UserID.new("123")
+	assert_equal user_id.double, 6
+end
+
+test "#===" do
+	user_id = UserID.new("123")
+
+	assert user_id === user_id
+	refute user_id === "123"
+end

--- a/test/value.test.rb
+++ b/test/value.test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+UserID = Literal::Value(Integer)
+Age = Literal::Value(Integer, 18..)
+Name = Literal::Value(String) do
+	delegate :length
+end
+
+test do
+	user_id = UserID.new(123)
+	assert_equal(123, user_id.to_i)
+
+	assert_raises Literal::TypeError do
+		Age.new(17)
+	end
+
+	name = Name.new("Joel")
+	assert_equal 4, name.length
+end


### PR DESCRIPTION
This PR introduces `Literal::Value` objects. Literal::Values are designed to wrap primitives (though they can wrap any object) in a branded object allowing for more precise type-matching.

```ruby
UserID = Literal::Value(Integer)

my_user_id = UserID.new(123)
```

### Constraints

You can pass constraints, same as `_Constraint`

```ruby
Username = Literal::Value(String, length: 3..15)
```

### Coercion

Literal value classes can be coerced into a coercion by default

```ruby
prop :user, UserID, &UserID
```

### Delegation

You can delegate to underlying methods

```ruby
Username = Literal::Value(String) do
  delegate :length
end
```

Literal will default to delegating to basic coercion methods. For example, if your value is a String, it will delegate `to_s` and `to_str` to the underlying value by default. Otherwise, delegation is explicit.

Only delegate what you need. Constraining the interface allows for more flexibility later on. If you want to replace a value object with a regular object, you won’t need to re-implement the entire interface of a primitive.

### Customisation

```ruby
Name = Literal::Value(String) do
  def first
    @value.split(" ").first
  end
end
```

### Freezing

Literal value classes and literal value objects are frozen by default, though their underlying values are not automatically frozen.