### PR TITLE
feat: Allow private-scoped after_initialize hooks

### DIFF
--- a/lib/literal/properties/schema.rb
+++ b/lib/literal/properties/schema.rb
@@ -62,7 +62,7 @@ class Literal::Properties::Schema
 	end
 
 	def generate_after_initializer(buffer = +"")
-		buffer << "  after_initialize if respond_to?(:after_initialize)\n"
+		buffer << "  after_initialize if respond_to?(:after_initialize, true)\n"
 	end
 
 	def generate_to_h(buffer = +"")

--- a/test/properties.test.rb
+++ b/test/properties.test.rb
@@ -182,7 +182,7 @@ end
 test "after initialize callback" do
 	callback_called = false
 
-	example = Class.new do
+	public_callback = Class.new do
 		extend Literal::Properties
 
 		prop :name, String
@@ -192,7 +192,43 @@ test "after initialize callback" do
 		end
 	end
 
-	example.new(name: "John")
+	public_callback.new(name: "John")
+
+	assert callback_called
+
+	callback_called = false
+
+	protected_callback = Class.new do
+		extend Literal::Properties
+
+		prop :name, String
+
+		define_method :after_initialize do
+			callback_called = true
+		end
+
+		protected :after_initialize
+	end
+
+	protected_callback.new(name: "John")
+
+	assert callback_called
+
+	callback_called = false
+
+	private_callback = Class.new do
+		extend Literal::Properties
+
+		prop :name, String
+
+		define_method :after_initialize do
+			callback_called = true
+		end
+
+		private :after_initialize
+	end
+
+	private_callback.new(name: "John")
 
 	assert callback_called
 


### PR DESCRIPTION
`after_initialize` hook comes very handy with `Literal::Data`, when we want to, for example freeze some of the complex properties passed in. But making this method public seems a bit incorrect.