### PR TITLE
Make the rails enum integration aware of the original type

### DIFF
--- a/lib/literal/rails/enum_macro.rb
+++ b/lib/literal/rails/enum_macro.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Literal::Rails::EnumMacro
+	def literal_enum(attribute_name, enum, **)
+		attribute(attribute_name, :literal_enum, type: enum, subtype: type_for_attribute(attribute_name), **)
+	end
+end

--- a/lib/literal/rails/enum_type.rb
+++ b/lib/literal/rails/enum_type.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class Literal::Rails::EnumType < ActiveModel::Type::Value
-	def initialize(enum)
+	def initialize(enum, subtype)
 		@enum = enum
+		@subtype = subtype || ActiveModel::Type::Value.new
 		super()
 	end
 
@@ -14,8 +15,10 @@ class Literal::Rails::EnumType < ActiveModel::Type::Value
 		case value
 		when nil
 			nil
+		when @enum
+			value
 		else
-			@enum.coerce(value)
+			@enum.coerce(@subtype.cast(value))
 		end
 	end
 
@@ -24,7 +27,7 @@ class Literal::Rails::EnumType < ActiveModel::Type::Value
 		when nil
 			nil
 		else
-			@enum.coerce(value).value
+			@subtype.serialize(@enum.coerce(value).value)
 		end
 	end
 
@@ -33,7 +36,7 @@ class Literal::Rails::EnumType < ActiveModel::Type::Value
 		when nil
 			nil
 		else
-			@enum.coerce(value)
+			@enum.coerce(@subtype.deserialize(value))
 		end
 	end
 end

--- a/lib/literal/railtie.rb
+++ b/lib/literal/railtie.rb
@@ -3,13 +3,15 @@
 class Literal::Railtie < Rails::Railtie
 	initializer "literal.register_literal_enum_type" do
 		[ActiveRecord::Type, ActiveModel::Type].each do |registry|
-			registry.register(:literal_enum) do |name, type:|
-				Literal::Rails::EnumType.new(type)
+			registry.register(:literal_enum) do |name, type:, subtype:|
+				Literal::Rails::EnumType.new(type, subtype)
 			end
 
 			registry.register(:literal_flags) do |name, type:|
 				Literal::Rails::FlagsType.new(type)
 			end
 		end
+
+		ActiveRecord::Base.extend Literal::Rails::EnumMacro
 	end
 end


### PR DESCRIPTION
This change makes the `:literal_enum` attribute type, _type-aware_ of the attribute that it is replacing.

Additionally it adds a `literal_enum` macro to `ActiveRecord::Base` that delegates to `attribute` and figures out the underlying attribute type.

My concern here is with calling `type_for_attribute` at class evaluation time is going to trigger a connection to the DB. This change broke my reproduction script because I created the database _after_ defining the model. But this change makes the model definition require the database to be set up already.

Unfortunately I don't think we can lazy evaluate the `type_for_attribute` because after the call to `attribute` it's type will have changed to `:literal_enum`.