### PR TITLE
feat: Make data structs implicitly Hash coercible

### DIFF
--- a/lib/literal/data_structure.rb
+++ b/lib/literal/data_structure.rb
@@ -14,6 +14,8 @@ class Literal::DataStructure
 		{}
 	end
 
+	alias to_hash to_h
+
 	def deconstruct
 		to_h.values
 	end

--- a/lib/literal/properties.rb
+++ b/lib/literal/properties.rb
@@ -92,6 +92,8 @@ module Literal::Properties
 					{}
 				end
 
+				alias to_hash to_h
+
 				set_temporary_name "Literal::Properties(Extension)" if respond_to?(:set_temporary_name)
 			end
 		end

--- a/lib/literal/properties/schema.rb
+++ b/lib/literal/properties/schema.rb
@@ -78,6 +78,7 @@ class Literal::Properties::Schema
 		end
 
 		buffer << "  }\n" << "end\n"
+		buffer << "alias to_hash to_h\n"
 	end
 
 	def generate_hash(buffer = +"")

--- a/test/data.test.rb
+++ b/test/data.test.rb
@@ -53,6 +53,12 @@ test "can be deconstructed with keys" do
 	assert_equal(person.deconstruct_keys([:name]), { name: "John" })
 end
 
+test "can be implicitly coerced to Hash" do
+	person = Person.new(name: "John")
+
+	assert_equal({ last_name: "Doe" }.merge(person), { last_name: "Doe", name: "John" })
+end
+
 test "can be used as a hash key" do
 	person = Person.new(name: "John")
 	person2 = Person.new(name: "Bob")


### PR DESCRIPTION
This allows using `Literal::Data` (and its friends) like so:

``` ruby
class Person < Literal::Data
  prop :first_name, String
  prop :last_name,  String
end

john = Person.new(first_name: "John", last_name: "Doe")
jane = Person.new(**john, first_name: "Jane")
```

This is especially useful when we use Data/Struct as configuration options data:

``` ruby
class Shrine
  module Plugins
    module Example
      class Options < Literal::Data
        # ...
      end

      DEFAULT_OPTIONS = { ... }

      def self.configure(uploader, **options)
        uploader.opts[:example] = Options.new(
          **DEFAULT_OPTIONS,
          **uploader.opts[:example],
          **options
        )
      end
    end

    register_plugin(:example, Example)
  end
end
```