### PR TITLE
POC: Refactor Literal::Enum finders

### DIFF
--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -47,34 +47,23 @@ class Literal::Enum
 		end
 
 		def where(**kwargs)
-			unless kwargs.length == 1
-				raise ArgumentError.new("You can only specify one index when using `where`.")
+			results = []
+
+			kwargs.each do |key, lookup|
+				matches = []
+
+				@indexes.fetch(key).each do |value, enums|
+					matches.concat(enums) if lookup === value
+				end
+
+				results << matches
 			end
 
-			key, value = kwargs.first
-
-			types = @indexes_definitions.fetch(key)
-			type = types.first
-			Literal.check(value, type) { |c| raise NotImplementedError }
-
-			@indexes.fetch(key)[value]
+			results.inject(:&)
 		end
 
 		def find_by(**kwargs)
-			unless kwargs.length == 1
-				raise ArgumentError.new("You can only specify one index when using `where`.")
-			end
-
-			key, value = kwargs.first
-
-			unless @indexes_definitions.fetch(key)[1]
-				raise ArgumentError.new("You can only use `find_by` on unique indexes.")
-			end
-
-			type = @indexes_definitions.fetch(key)[0]
-			Literal.check(value, type)
-
-			@indexes.fetch(key)[value]&.first
+			where(**kwargs).first
 		end
 
 		def _load(data)


### PR DESCRIPTION
Allow multiple criterias and more complex values. Example:

``` ruby
class Example < Literal::Enum(String)
  prop :score, Integer

	index :score, Integer, unique: false

	A = new("a", score: 5)
	B = new("b", score: 4)
	C = new("c", score: 3)
	D = new("d", score: 2)
	E = new("e", score: 1)
end

Example.where(score: 2..4)          # => [Example::B, Example::C, Example::D]
Example.where(score: :odd?.to_proc) # => [Example::A, Example::C, Example::E]
```

I agree that multi-key filtering is probably not needed, but I do think that:

1. `find_by(...)` should be as simple as `where(...).first`
2. `where(k: v)` should allow non-literal values for filtering

If this is something that can be considered - I will revamp this PR and tests.