### PR TITLE
Runtime assertions with `binding.assert`

### DIFF
--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -19,6 +19,52 @@ module Literal
 		loader.setup
 	end
 
+	CLASS_METHOD = Kernel.instance_method(:class)
+	CLASS_VARIABLE_GET_METHOD = Module.instance_method(:class_variable_get)
+	INSTANCE_VARIABLE_GET_METHOD = Kernel.instance_method(:instance_variable_get)
+
+	module BindingAssert
+		def assert(...)
+			Literal.assert(self, ...)
+		end
+	end
+
+	::Binding.include(Literal::BindingAssert)
+
+
+	def self.assert(bind, **kwargs)
+		kwargs.each do |name, type|
+			string_name = (Symbol === name) ? name.name : name
+			first_byte = string_name.getbyte(0)
+
+			if first_byte == 64 # @foo
+				if string_name.getbyte(1) == 64 # @@foo
+					value = CLASS_VARIABLE_GET_METHOD.bind_call(
+						CLASS_METHOD.bind_call(bind.receiver), name
+					)
+				else # @foo
+					value = INSTANCE_VARIABLE_GET_METHOD.bind_call(bind.receiver, name)
+				end
+			elsif first_byte == 36 # $foo
+				raise if string_name.match?(/[\s\.]/)
+				value = eval(string_name)
+			else # foo
+				value = bind.local_variable_get(name)
+			end
+
+			unless type === value
+				raise ::TypeError.new(<<~MESSAGE)
+					Assertion failed!
+
+					  #{name}
+					    Expected: #{type.inspect}
+					    Actual (#{value.class}): #{value.inspect}
+				MESSAGE
+			end
+		end
+	end
+
+
 	def self.Value(*args, **kwargs, &block)
 		value_class = Class.new(Literal::Value)
 

--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -24,9 +24,7 @@ module Literal
 	INSTANCE_VARIABLE_GET_METHOD = Kernel.instance_method(:instance_variable_get)
 
 	module BindingAssert
-		def assert(...)
-			Literal.assert(self, ...)
-		end
+		def assert(...) = Literal.assert(self, ...)
 	end
 
 	::Binding.include(Literal::BindingAssert)

--- a/test/assert.test.rb
+++ b/test/assert.test.rb
@@ -1,0 +1,50 @@
+$a = 1
+
+test "assert with local variable" do
+	refute_raises do
+		a = 1
+		b = "Hello"
+
+		binding.assert(a: Integer, b: String)
+		binding.assert("a" => Integer, "b" => String)
+	end
+
+	assert_raises TypeError do
+		a = 1
+		binding.assert(a: String)
+	end
+end
+
+test "assert with global variable" do
+	refute_raises do
+		binding.assert("$a": Integer)
+	end
+
+	assert_raises TypeError do
+		binding.assert("$a": String)
+	end
+end
+
+test "assert with instance variable" do
+	refute_raises do
+		@a = 1
+		binding.assert("@a": Integer)
+	end
+
+	assert_raises TypeError do
+		@a = 1
+		binding.assert("@a": String)
+	end
+end
+
+test "assert with class variable" do
+	refute_raises do
+		@@a = 1
+		binding.assert("@@a": Integer)
+	end
+
+	assert_raises TypeError do
+		@@a = 1
+		binding.assert("@@a": String)
+	end
+end


### PR DESCRIPTION
This PR introduces a `Binding` patch that allows you to make assertions about local variables at any point.

```ruby
def add(a, b)
  binding.assert(a: Numeric, b: Numeric)
  a + b
end
```

You would ideally include `Literal::Types` into `Object` if you wanted to make the best use of this, since otherwise the `_` types are not available in the context of an instance.

It would be nice if there was an equally clean way to make assertions about instance variables.