### PR TITLE
feat: Custom property classes

### DIFF
--- a/lib/literal/properties.rb
+++ b/lib/literal/properties.rb
@@ -13,7 +13,7 @@ module Literal::Properties
 		base.include(base.__send__(:__literal_extension__))
 	end
 
-	def prop(name, type, kind = :keyword, reader: false, writer: false, predicate: false, default: nil, &coercion)
+	def prop(name, type, kind = :keyword, reader: false, writer: false, predicate: false, default: nil, **kwargs, &coercion)
 		if default && !(Proc === default || default.frozen?)
 			raise Literal::ArgumentError.new("The default must be a frozen object or a Proc.")
 		end
@@ -48,6 +48,7 @@ module Literal::Properties
 			writer:,
 			predicate:,
 			default:,
+			**kwargs,
 			coercion:,
 		)
 

--- a/test/properties/custom_property_class.test.rb
+++ b/test/properties/custom_property_class.test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+class DescriptionProperty < Literal::Property
+	def initialize(description: nil, **kwargs)
+		super(**kwargs)
+
+		@description = description
+	end
+
+	attr_reader :description
+end
+
+module DescriptionProperties
+	def prop(name, type, kind = :keyword, description: nil, **, &coercion)
+		super
+	end
+
+	def __literal_property_class__
+		DescriptionProperty
+	end
+end
+
+Example = Literal::Object
+
+test "custom property class can accept additional keyword arguments" do
+	example = Class.new(Example) do
+		extend DescriptionProperties
+
+		prop :name, String, description: "The person's name"
+		prop :age, Integer, description: "The person's age"
+	end
+
+	name_prop = example.literal_properties[:name]
+	age_prop = example.literal_properties[:age]
+
+	assert_equal name_prop.description, "The person's name"
+	assert_equal age_prop.description, "The person's age"
+	assert_equal name_prop.class, DescriptionProperty
+	assert_equal age_prop.class, DescriptionProperty
+end
+
+test "custom property class works with all property features" do
+	example = Class.new(Example) do
+		extend DescriptionProperties
+
+		prop :name, String, description: "Name", reader: :public
+		prop :age, Integer, description: "Age", default: 0, reader: :public
+	end
+
+	object = example.new(name: "John")
+	assert_equal object.name, "John"
+	assert_equal object.age, 0
+
+	name_prop = example.literal_properties[:name]
+	age_prop = example.literal_properties[:age]
+
+	assert_equal name_prop.description, "Name"
+	assert_equal age_prop.description, "Age"
+end
+
+test "custom property class with nil description" do
+	example = Class.new(Example) do
+		extend DescriptionProperties
+
+		prop :name, String
+	end
+
+	name_prop = example.literal_properties[:name]
+	assert_equal name_prop.description, nil
+end
+
+test "invalid keyword arguments on base Literal::Properties raise ArgumentError" do
+	example = Class.new(Example)
+
+	assert_raises(ArgumentError) do
+		example.prop :name, String, description: "This should fail"
+	end
+end
+
+test "invalid keyword arguments on base Literal::Properties raise ArgumentError for other unknown args" do
+	example = Class.new(Example)
+
+	assert_raises(ArgumentError) do
+		example.prop :name, String, unknown_arg: "This should fail"
+	end
+end


### PR DESCRIPTION
I was looking into creating a custom property class to try and output OpenAPI / Swagger schema, but I couldn't get the keyword arguments to pass into my new class. This change adds `**kwargs` to the `prop` constructor so that downstream modules / classes can send additional args to the custom property class.

## Changes

* Add `**kwargs` to `Literal::Properties.prop`
* Tests for custom property classes

## Example

```ruby
class DescriptionProperty < Literal::Property
	def initialize(description: nil, **kwargs)
		super(**kwargs)

		@description = description
	end

	attr_reader :description
end

module DescriptionProperties
	def prop(name, type, kind = :keyword, description: nil, **, &coercion)
		super
	end

	def __literal_property_class__
		DescriptionProperty
	end
end

class Example < Literal::Object
	extend DescriptionProperties

	prop :name, String, description: "The person's name"
	prop :age, Integer, description: "The person's age"
end

# irb:> Example.literal_properties
# =>
#   #<Literal::Properties::Schema:0x0000000120e6d6f8
#   @mutex=#<Thread::Mutex:0x0000000120e6c618>,
#     @properties_index=
#       {name: #<DescriptionProperty:0x00000001217fadd8 @coercion=nil, @default=nil, @description="The person's name", @kind=:keyword, @name=:name, @predicate=false, @reader=false, @type=String, @writer=false>,
#          age: #<DescriptionProperty:0x00000001217f97f8 @coercion=nil, @default=nil, @description="The person's age", @kind=:keyword, @name=:age, @predicate=false, @reader=false, @type=Integer, @writer=false>},
# @sorted_properties=
#   [#<DescriptionProperty:0x00000001217fadd8 @coercion=nil, @default=nil, @description="The person's name", @kind=:keyword, @name=:name, @predicate=false, @reader=false, @type=String, @writer=false>,
#   #<DescriptionProperty:0x00000001217f97f8 @coercion=nil, @default=nil, @description="The person's age", @kind=:keyword, @name=:age, @predicate=false, @reader=false, @type=Integer, @writer=false>]>
``` 