### PR TITLE
`Literal::TypeError` tweaks and fix for type check in `Enum`

### DIFF
--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -124,9 +124,7 @@ class Literal::Enum
 				index = @members.group_by(&block).freeze
 
 				index.each do |key, values|
-					unless type === key
-						raise Literal::TypeError.expected(key, to_be_a: type)
-					end
+					Literal.check(key, type)
 
 					if unique && values.size > 1
 						raise ArgumentError.new("The index #{name} is not unique.")

--- a/lib/literal/errors/type_error.rb
+++ b/lib/literal/errors/type_error.rb
@@ -52,8 +52,6 @@ class Literal::TypeError < TypeError
 				children: @children.map(&:to_h),
 			}
 		end
-
-		alias to_hash to_h
 	end
 
 	def initialize(context:)

--- a/lib/literal/errors/type_error.rb
+++ b/lib/literal/errors/type_error.rb
@@ -87,7 +87,8 @@ class Literal::TypeError < TypeError
 	end
 
 	def deconstruct_keys(keys)
-		to_h.slice(*keys)
+		h = to_h
+		keys ? h.slice(*keys) : h
 	end
 
 	def to_h

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -231,11 +231,9 @@ end
 test "index with wrong type raises Literal::TypeError" do
 	assert_raises(Literal::TypeError) do
 		Class.new(Literal::Enum(Integer)) do
-			index :bad_index, String do |member|
-				member.value # returns Integer, not String
-			end
+			index :bad_index, String, &:value
 
-			A = new(1)
+			const_set(:A, new(1))
 
 			__after_defined__
 		end

--- a/test/enum.test.rb
+++ b/test/enum.test.rb
@@ -227,3 +227,17 @@ test "pattern matching" do
 	match { Color::Red => Color[1] }
 	match { Color::Red => Color[hex: "#FF0000"] }
 end
+
+test "index with wrong type raises Literal::TypeError" do
+	assert_raises(Literal::TypeError) do
+		Class.new(Literal::Enum(Integer)) do
+			index :bad_index, String do |member|
+				member.value # returns Integer, not String
+			end
+
+			A = new(1)
+
+			__after_defined__
+		end
+	end
+end


### PR DESCRIPTION
`TypeError#deconstruct_keys` prob should return all keys when passed `nil` like `Hash` say 

It is probably not useful to implicitly convert `Context` to hash so can remove extra `to_hash` alias (unless we think we might need it)

`Enum` `__after_defined__` still using old `TypeError` class method so update it to use `Literal.check`