### PR TITLE
Allow passing block to Data definition

### DIFF
--- a/lib/literal/data.rb
+++ b/lib/literal/data.rb
@@ -4,9 +4,13 @@ class Literal::Data < Literal::DataStructure
 	class << self
 		def [](...) = new(...)
 
-		def define(**properties)
+		def define(**properties, &body)
 			Class.new(self) do
 				properties.each { |name, type| prop(name, type) }
+
+				if block_given?
+					class_exec(&body)
+				end
 			end
 		end
 

--- a/test/data.test.rb
+++ b/test/data.test.rb
@@ -90,6 +90,19 @@ test "define" do
 	assert_equal(person_with_define.to_h, person.to_h)
 end
 
+test "define block" do
+	Rect = Literal::Data.define(w: Integer, h: Integer) do
+		prop :filled, _Boolean, default: false, predicate: :public
+
+		def area = @w * @h
+	end
+
+	rect = Rect[w: 5, h: 4, filled: true]
+
+	assert_equal(rect.area, 20)
+	assert rect.filled?
+end
+
 test "initialize with [] method" do
 	person_a = Person.new(name: "John")
 	person_b = Person[name: "John"]


### PR DESCRIPTION
From [Ruby docs](https://docs.ruby-lang.org/en/master/Data.html):

> The native Data [::define](https://docs.ruby-lang.org/en/master/Data.html#method-c-define) method accepts an optional block and evaluates it in the context of the newly defined class. That allows to define additional methods:
> ```ruby
> Measure = Data.define(:amount, :unit) do
>   def <=>(other)
>     return unless other.is_a?(self.class) && other.unit == unit
>     amount <=> other.amount
>   end
> 
>   include Comparable
> end
> ```

This will be useful for Literal when it is necessary to define custom properties/methods inside `Literal::Data.define`, eg:
```ruby
Success = Literal::Data.define(user: User) do
  def success? = true
  def failure? = false
end

Failure = Literal::Data.define(reason: String, user: User) do
  def success? = false
  def failure? = true
end
```