### PR TITLE
Add recursive JSON Schema refs

### DIFF
--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -10,6 +10,7 @@ module Literal
 		loader.ignore("#{__dir__}/ruby_lsp")
 
 		loader.inflector.inflect(
+			"json_data_serializer" => "JSONDataSerializer",
 			"json_data_type" => "JSONDataType",
 			"json_schema" => "JSONSchema",
 			"json_schema_number_serializer" => "JSONSchemaNumberSerializer"

--- a/lib/literal/data_structure.rb
+++ b/lib/literal/data_structure.rb
@@ -4,6 +4,14 @@
 class Literal::DataStructure
 	extend Literal::Properties
 
+	class << self
+		def literal_child_types
+			return enum_for(__method__) unless block_given?
+
+			literal_properties.each { |property| yield property.type }
+		end
+	end
+
 	def self.from_pack(payload)
 		object = allocate
 		object.marshal_load(payload)

--- a/lib/literal/json_schema/generator.rb
+++ b/lib/literal/json_schema/generator.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class Literal::JSONSchema::Generator
+	def initialize(context)
+		@context = context
+		@definitions = {}
+		@depth = 0
+	end
+
+	def schema(type, reference: true)
+		type = type.materialize if type in Literal::Types::DeferredType
+
+		root = @depth.zero?
+		@depth += 1
+
+		schema = if reference && !root && named_structure_type?(type)
+			reference_schema(type)
+		else
+			@context.build_json_schema(type, generator: self)
+		end
+
+		if root && @definitions.any?
+			schema.merge("$defs" => @definitions.compact)
+		else
+			schema
+		end
+	ensure
+		@depth -= 1
+	end
+
+	private def reference_schema(type)
+		name = definition_name(type)
+
+		unless @definitions.key?(name)
+			@definitions[name] = nil
+			@definitions[name] = schema(type, reference: false)
+		end
+
+		{ "$ref" => "#/$defs/#{json_pointer_escape(name)}" }
+	end
+
+	private def definition_name(type)
+		type.name
+	end
+
+	private def json_pointer_escape(value)
+		value.gsub("~", "~0").gsub("/", "~1")
+	end
+
+	private def structure_type?(type)
+		type = type.materialize if type in Literal::Types::DeferredType
+
+		Class === type && type < Literal::DataStructure
+	end
+
+	private def named_structure_type?(type)
+		structure_type?(type) && type.name
+	end
+end

--- a/lib/literal/serialization_context.rb
+++ b/lib/literal/serialization_context.rb
@@ -3,14 +3,36 @@
 class Literal::SerializationContext
 	include Literal::Types
 
-	def initialize(*serializers)
+	DefaultSerializers = [
+		Literal::StringSerializer,
+		Literal::SymbolSerializer,
+		Literal::IntegerSerializer,
+		Literal::JSONSchemaNumberSerializer,
+		Literal::FloatSerializer,
+		Literal::BooleanSerializer,
+		Literal::DateSerializer,
+		Literal::StructureSerializer,
+		Literal::TaggedUnionSerializer,
+		Literal::UnionSerializer,
+		Literal::HashSerializer,
+		Literal::MapSerializer,
+		Literal::TupleSerializer,
+		Literal::ArraySerializer,
+		Literal::SetSerializer,
+		Literal::NilableSerializer,
+		Literal::JSONDataSerializer,
+	].freeze
+
+	def initialize(*serializers, defaults: true)
+		serializers = [*serializers, *DefaultSerializers] if defaults
+
 		@type = _Deferred { @type }
 		@kind = _Deferred { @kind }
 
 		@serializers = serializers.map { |it| it.new(self) }.freeze
 		@serializer_kinds = @serializers.to_h { |serializer| [serializer, _Kind(serializer.type)] }.freeze
 
-		@type = _Union(*@serializers.map(&:type))
+		@type = Literal::Serializer::SerializableType.new(_Union(*@serializers.map(&:type)))
 		@kind = _Union(*@serializer_kinds.values)
 
 		freeze
@@ -20,17 +42,19 @@ class Literal::SerializationContext
 	attr_reader :type
 	attr_reader :kind
 
-	def json_schema(type)
-		type = type.materialize if type in Literal::Types::DeferredType
-
-		serializer = serializer_for_type(type)
-		serializer.json_schema(type)
+	def json_schema(type, generator: nil, reference: true)
+		generator ||= Literal::JSONSchema::Generator.new(self)
+		generator.schema(type, reference:)
 	end
 
 	def serialize(value, type:, strict: true)
 		type = type.materialize if type in Literal::Types::DeferredType
 
-		serializer = serializer_for_type(type)
+		if aggregate_type?(type)
+			serializer, type = serializer_for_value(value)
+		else
+			serializer = serializer_for_type(type)
+		end
 
 		if strict && !(type === value)
 			raise Literal::ArgumentError, "Value #{value.inspect} cannot be serialized as #{type.inspect}"
@@ -76,7 +100,32 @@ class Literal::SerializationContext
 		@serializer_kinds.fetch(serializer)
 	end
 
+	def serializable_type?(type)
+		@type.serializable?(type)
+	end
+
+	def build_json_schema(type, generator:)
+		type = type.materialize if type in Literal::Types::DeferredType
+
+		serializer = serializer_for_type(type)
+		serializer.json_schema(type, generator:)
+	end
+
 	private def serializer_matching_type(type)
 		@serializers.find { |it| serializer_kind(it) === type }
+	end
+
+	private def serializer_for_value(value)
+		@serializers.each do |serializer|
+			if (type = serializer.value_type(value))
+				return [serializer, type]
+			end
+		end
+
+		raise Literal::ArgumentError, "Value #{value.inspect} cannot be serialized as #{@type.inspect}"
+	end
+
+	private def aggregate_type?(type)
+		Literal::Serializer::SerializableType === type
 	end
 end

--- a/lib/literal/serializer.rb
+++ b/lib/literal/serializer.rb
@@ -16,8 +16,12 @@ class Literal::Serializer
 		@context.deserialize(value, type:, strict: false)
 	end
 
-	def json_schema_for(type)
-		@context.json_schema(type)
+	def json_schema_for(type, generator:, reference: true)
+		@context.json_schema(type, generator:, reference:)
+	end
+
+	def value_type(value)
+		type if type === value
 	end
 
 	def mergeable_object?(type)

--- a/lib/literal/serializer/serializable_type.rb
+++ b/lib/literal/serializer/serializable_type.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "set"
+
+class Literal::Serializer::SerializableType
+	include Literal::Type
+
+	def initialize(type)
+		@type = type
+		freeze
+	end
+
+	attr_reader :type
+
+	def inspect
+		@type.inspect
+	end
+
+	def ===(value)
+		@type === value
+	end
+
+	def >=(other, context: nil)
+		serializable?(other) && Literal.subtype?(other, @type, context:)
+	end
+
+	def serializable?(type)
+		serializable_type?(type)
+	end
+
+	private def serializable_type?(type, stack: Set[], seen: Set[])
+		type = type.materialize if type in Literal::Types::DeferredType
+		key = type.object_id
+
+		return dereferenceable_type?(type) if stack.include?(key)
+		return true if seen.include?(key)
+		return true unless type.respond_to?(:literal_child_types)
+
+		stack.add(key)
+
+		type.literal_child_types.all? do |child_type|
+			serializable_type?(child_type, stack:, seen:)
+		end
+	ensure
+		if key
+			stack.delete(key)
+			seen.add(key)
+		end
+	end
+
+	private def dereferenceable_type?(type)
+		Class === type && type < Literal::DataStructure && type.name
+	end
+end

--- a/lib/literal/serializers/array_serializer.rb
+++ b/lib/literal/serializers/array_serializer.rb
@@ -8,14 +8,14 @@ class Literal::ArraySerializer < Literal::Serializer
 
 	attr_reader :type
 
-	def json_schema(type)
+	def json_schema(type, generator: nil)
 		{ "type" => "array" }.tap do |schema|
 			case type
 			when Literal::Types::ArrayType
-				schema["items"] = json_schema_for(type.type)
+				schema["items"] = json_schema_for(type.type, generator:)
 			when Literal::Types::ConstraintType
 				array_type = array_type_for(type)
-				schema["items"] = json_schema_for(array_type.type)
+				schema["items"] = json_schema_for(array_type.type, generator:)
 
 				type.property_constraints.each do |property, constraint|
 					case [property, constraint]

--- a/lib/literal/serializers/date_serializer.rb
+++ b/lib/literal/serializers/date_serializer.rb
@@ -7,7 +7,7 @@ class Literal::DateSerializer < Literal::Serializer
 		Type
 	end
 
-	def json_schema(type)
+	def json_schema(type, generator: nil)
 		case type
 		when Date
 			{ "type" => "string", "format" => "date", "const" => serialize_date(type) }

--- a/lib/literal/serializers/float_serializer.rb
+++ b/lib/literal/serializers/float_serializer.rb
@@ -7,12 +7,12 @@ class Literal::FloatSerializer < Literal::Serializer
 		Type
 	end
 
-	def json_schema(type)
+	def json_schema(type, generator: nil)
 		case type
 		when Float
 			{ "type" => "number", "const" => type }
 		when Literal::Types::UnionType
-			union_json_schema(type)
+			union_json_schema(type, generator:)
 		when Literal::Types::ConstraintType
 			constraint_json_schema(type)
 		else
@@ -37,11 +37,11 @@ class Literal::FloatSerializer < Literal::Serializer
 		end
 	end
 
-	private def union_json_schema(type)
+	private def union_json_schema(type, generator:)
 		if type.types.empty?
 			{ "type" => "number", "enum" => type.primitives.to_a }
 		else
-			{ "anyOf" => type.map { |member| json_schema_for(member) }.to_a }
+			{ "anyOf" => type.map { |member| json_schema_for(member, generator:) }.to_a }
 		end
 	end
 

--- a/lib/literal/serializers/hash_serializer.rb
+++ b/lib/literal/serializers/hash_serializer.rb
@@ -8,10 +8,10 @@ class Literal::HashSerializer < Literal::Serializer
 
 	attr_reader :type
 
-	def json_schema(type)
+	def json_schema(type, generator: nil)
 		hash_type = hash_type_for(type)
-		key_schema = json_schema_for(hash_type.key_type)
-		value_schema = json_schema_for(hash_type.value_type)
+		key_schema = json_schema_for(hash_type.key_type, generator:)
+		value_schema = json_schema_for(hash_type.value_type, generator:)
 
 		schema = if string_key_schema?(key_schema)
 			{
@@ -74,7 +74,7 @@ class Literal::HashSerializer < Literal::Serializer
 	private def object_hash_type?(hash_type)
 		return false if Literal::Types::DeferredType === hash_type.key_type
 
-		string_key_schema?(json_schema_for(hash_type.key_type))
+		string_key_schema?(@context.json_schema(hash_type.key_type))
 	rescue Literal::ArgumentError
 		false
 	end

--- a/lib/literal/serializers/integer_serializer.rb
+++ b/lib/literal/serializers/integer_serializer.rb
@@ -7,14 +7,14 @@ class Literal::IntegerSerializer < Literal::Serializer
 		Type
 	end
 
-	def json_schema(type)
+	def json_schema(type, generator: nil)
 		case type
 		when Literal::JSONSchema::IntegerType
 			type.json_schema
 		when Integer
 			{ "type" => "integer", "const" => type }
 		when Literal::Types::UnionType
-			union_json_schema(type)
+			union_json_schema(type, generator:)
 		when Literal::Types::ConstraintType
 			constraint_json_schema(type)
 		else
@@ -41,11 +41,11 @@ class Literal::IntegerSerializer < Literal::Serializer
 		end
 	end
 
-	private def union_json_schema(type)
+	private def union_json_schema(type, generator:)
 		if type.types.empty?
 			{ "type" => "integer", "enum" => type.primitives.to_a }
 		else
-			{ "anyOf" => type.map { |member| json_schema_for(member) }.to_a }
+			{ "anyOf" => type.map { |member| json_schema_for(member, generator:) }.to_a }
 		end
 	end
 

--- a/lib/literal/serializers/json_data_serializer.rb
+++ b/lib/literal/serializers/json_data_serializer.rb
@@ -1,19 +1,14 @@
 # frozen_string_literal: true
 
-class Literal::BooleanSerializer < Literal::Serializer
-	Type = _Boolean
+class Literal::JSONDataSerializer < Literal::Serializer
+	Type = _JSONData
 
 	def type
 		Type
 	end
 
 	def json_schema(type, generator: nil)
-		case type
-		when true, false
-			{ "type" => "boolean", "const" => type }
-		else
-			{ "type" => "boolean" }
-		end
+		true
 	end
 
 	def serialize(value, type:)

--- a/lib/literal/serializers/json_schema_number_serializer.rb
+++ b/lib/literal/serializers/json_schema_number_serializer.rb
@@ -7,7 +7,7 @@ class Literal::JSONSchemaNumberSerializer < Literal::Serializer
 		Type
 	end
 
-	def json_schema(type)
+	def json_schema(type, generator: nil)
 		type.json_schema
 	end
 

--- a/lib/literal/serializers/map_serializer.rb
+++ b/lib/literal/serializers/map_serializer.rb
@@ -25,11 +25,11 @@ class Literal::MapSerializer < Literal::Serializer
 
 	attr_reader :type
 
-	def json_schema(type)
+	def json_schema(type, generator: nil)
 		{
 			"type" => "object",
 			"properties" => type.shape.to_h do |key, value_type|
-				[key.name, json_schema_for(value_type)]
+				[key.name, json_schema_for(value_type, generator:)]
 			end,
 			"required" => type.shape.reject { |_key, value_type| value_type === nil }.keys.map(&:name),
 			"additionalProperties" => false,

--- a/lib/literal/serializers/nilable_serializer.rb
+++ b/lib/literal/serializers/nilable_serializer.rb
@@ -36,13 +36,13 @@ class Literal::NilableSerializer < Literal::Serializer
 
 	attr_reader :type
 
-	def json_schema(type)
+	def json_schema(type, generator: nil)
 		return { "type" => "null" } if type.nil?
 		return { "type" => "null" } if Literal::Serializer::NilableType === type
 
 		{
 			"anyOf" => [
-				json_schema_for(type.type),
+				json_schema_for(type.type, generator:),
 				{ "type" => "null" },
 			],
 		}

--- a/lib/literal/serializers/set_serializer.rb
+++ b/lib/literal/serializers/set_serializer.rb
@@ -8,14 +8,14 @@ class Literal::SetSerializer < Literal::Serializer
 
 	attr_reader :type
 
-	def json_schema(type)
+	def json_schema(type, generator: nil)
 		{ "type" => "array", "uniqueItems" => true }.tap do |schema|
 			case type
 			when Literal::Types::SetType
-				schema["items"] = json_schema_for(type.type)
+				schema["items"] = json_schema_for(type.type, generator:)
 			when Literal::Types::ConstraintType
 				set_type = set_type_for(type)
-				schema["items"] = json_schema_for(set_type.type)
+				schema["items"] = json_schema_for(set_type.type, generator:)
 
 				type.property_constraints.each do |property, constraint|
 					case [property, constraint]

--- a/lib/literal/serializers/string_serializer.rb
+++ b/lib/literal/serializers/string_serializer.rb
@@ -7,14 +7,14 @@ class Literal::StringSerializer < Literal::Serializer
 		Type
 	end
 
-	def json_schema(type)
+	def json_schema(type, generator: nil)
 		case type
 		when Literal::JSONSchema::StringType
 			type.json_schema
 		when String
 			{ "type" => "string", "const" => type }
 		when Literal::Types::UnionType
-			union_json_schema(type)
+			union_json_schema(type, generator:)
 		when Literal::Types::ConstraintType
 			constraint_json_schema(type)
 		else
@@ -34,11 +34,11 @@ class Literal::StringSerializer < Literal::Serializer
 		range.exclude_end? ? range.end - 1 : range.end
 	end
 
-	private def union_json_schema(type)
+	private def union_json_schema(type, generator:)
 		if type.types.empty?
 			{ "type" => "string", "enum" => type.primitives.to_a }
 		else
-			{ "anyOf" => type.map { |member| json_schema_for(member) }.to_a }
+			{ "anyOf" => type.map { |member| json_schema_for(member, generator:) }.to_a }
 		end
 	end
 

--- a/lib/literal/serializers/structure_serializer.rb
+++ b/lib/literal/serializers/structure_serializer.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require "set"
+
 class Literal::Serializer::StructureType
 	include Literal::Type
 
-	def initialize(kind)
-		@kind = kind
+	def initialize(context)
+		@context = context
 		freeze
 	end
 
@@ -13,15 +15,49 @@ class Literal::Serializer::StructureType
 	end
 
 	def ===(object)
-		Literal::DataStructure === object && object.class.literal_properties.all? { |property| serializable_property_type?(property.type) }
+		Literal::DataStructure === object && serializable_structure_type?(object.class)
 	end
 
 	def >=(other, context: nil)
-		Class === other && other < Literal::DataStructure && other.literal_properties.all? { |property| serializable_property_type?(property.type) }
+		Class === other && other < Literal::DataStructure && serializable_structure_type?(other)
+	end
+
+	private def serializable_structure_type?(type)
+		@context.serializable_type?(type) && with_structure_guard(type) do
+			type.literal_properties.all? do |property|
+				property_type = property_schema_type(property.type)
+
+				serializable_property_type?(property_type) ||
+					recursive_property_type?(property_type, type)
+			end
+		end
 	end
 
 	private def serializable_property_type?(type)
-		@kind === property_schema_type(type)
+		Literal.subtype?(type, @context.type)
+	end
+
+	private def recursive_property_type?(type, root, stack: Set[])
+		type = type.materialize if type in Literal::Types::DeferredType
+
+		return dereferenceable_structure_type?(type) if type.equal?(root)
+		return true if serializable_property_type?(type)
+		return false unless type.respond_to?(:literal_child_types)
+
+		key = type.object_id
+		return false if stack.include?(key)
+
+		stack.add(key)
+
+		type.literal_child_types.all? do |child_type|
+			recursive_property_type?(child_type, root, stack:)
+		end
+	ensure
+		stack.delete(key) if key
+	end
+
+	private def dereferenceable_structure_type?(type)
+		Class === type && type < Literal::DataStructure && type.name
 	end
 
 	private def property_schema_type(type)
@@ -33,20 +69,38 @@ class Literal::Serializer::StructureType
 	private def undefined_optional?(type)
 		Literal::Types::UnionType === type && type.types.include?(Literal::Undefined)
 	end
+
+	private def with_structure_guard(type)
+		state = (Thread.current[:literal_serializable_structure_state] ||= {})
+		key = [object_id, type.object_id]
+
+		return true if state[key]
+
+		added = true
+		state[key] = true
+		yield
+	ensure
+		state&.delete(key) if added
+		Thread.current[:literal_serializable_structure_state] = nil if state&.empty?
+	end
 end
 
 class Literal::StructureSerializer < Literal::Serializer
 	def initialize(context)
 		@context = context
 
-		@type = Literal::Serializer::StructureType.new(@context.kind)
+		@type = Literal::Serializer::StructureType.new(@context)
 	end
 
 	attr_reader :type
 
-	def json_schema(type)
+	def value_type(value)
+		value.class if type === value
+	end
+
+	def json_schema(type, generator: nil)
 		properties = type.literal_properties.to_h do |property|
-			[property.name.to_s, property_json_schema(property)]
+			[property.name.to_s, property_json_schema(property, generator:)]
 		end
 
 		{
@@ -86,8 +140,8 @@ class Literal::StructureSerializer < Literal::Serializer
 		)
 	end
 
-	private def property_json_schema(property)
-		json_schema_for(property_schema_type(property.type)).tap do |schema|
+	private def property_json_schema(property, generator:)
+		json_schema_for(property_schema_type(property.type), generator:).tap do |schema|
 			schema["description"] = property.description if property.description?
 		end
 	end

--- a/lib/literal/serializers/symbol_serializer.rb
+++ b/lib/literal/serializers/symbol_serializer.rb
@@ -7,12 +7,12 @@ class Literal::SymbolSerializer < Literal::Serializer
 		Type
 	end
 
-	def json_schema(type)
+	def json_schema(type, generator: nil)
 		case type
 		when Symbol
 			{ "type" => "string", "const" => type.name }
 		when Literal::Types::UnionType
-			union_json_schema(type)
+			union_json_schema(type, generator:)
 		when Literal::Types::ConstraintType
 			constraint_json_schema(type)
 		else
@@ -28,11 +28,11 @@ class Literal::SymbolSerializer < Literal::Serializer
 		raw.to_sym
 	end
 
-	private def union_json_schema(type)
+	private def union_json_schema(type, generator:)
 		if type.types.empty?
 			{ "type" => "string", "enum" => type.primitives.map(&:name) }
 		else
-			{ "anyOf" => type.map { |member| json_schema_for(member) }.to_a }
+			{ "anyOf" => type.map { |member| json_schema_for(member, generator:) }.to_a }
 		end
 	end
 

--- a/lib/literal/serializers/tagged_union_serializer.rb
+++ b/lib/literal/serializers/tagged_union_serializer.rb
@@ -31,10 +31,13 @@ class Literal::TaggedUnionSerializer < Literal::Serializer
 
 	attr_reader :type
 
-	def json_schema(type)
+	def value_type(value)
+	end
+
+	def json_schema(type, generator: nil)
 		{
 			"oneOf" => type.members.map do |tag, member_type|
-				tagged_json_schema(tag.name, member_type)
+				tagged_json_schema(tag.name, member_type, generator:)
 			end,
 		}
 	end
@@ -67,8 +70,8 @@ class Literal::TaggedUnionSerializer < Literal::Serializer
 		end
 	end
 
-	private def tagged_json_schema(tag, member_type)
-		member_schema = json_schema_for(member_type)
+	private def tagged_json_schema(tag, member_type, generator:)
+		member_schema = json_schema_for(member_type, generator:, reference: false)
 
 		if mergeable_object_schema?(member_schema)
 			return merge_discriminator_schema(tag, member_schema)

--- a/lib/literal/serializers/tuple_serializer.rb
+++ b/lib/literal/serializers/tuple_serializer.rb
@@ -29,10 +29,10 @@ class Literal::TupleSerializer < Literal::Serializer
 
 	attr_reader :type
 
-	def json_schema(type)
+	def json_schema(type, generator: nil)
 		{
 			"type" => "array",
-			"prefixItems" => type.types.map { |member_type| json_schema_for(member_type) },
+			"prefixItems" => type.types.map { |member_type| json_schema_for(member_type, generator:) },
 			"minItems" => type.types.size,
 			"maxItems" => type.types.size,
 		}

--- a/lib/literal/serializers/union_serializer.rb
+++ b/lib/literal/serializers/union_serializer.rb
@@ -26,13 +26,13 @@ class Literal::Serializer::UnionType
 	SafeNaturalJSONTypes = Set["string", "integer", "number", "boolean", "null"].freeze
 	FiniteFloatType = Literal::Types._Float(finite?: true)
 
-	private def natural?(type)
+	private def natural?(type, generator: Literal::JSONSchema::Generator.new(@context))
 		seen = Set[]
 		has_integer = false
 		number_member = nil
 
 		type.each.all? do |member|
-			json_type = natural_json_type(member)
+			json_type = natural_json_type(member, generator:)
 			return false unless json_type
 
 			case json_type
@@ -48,8 +48,10 @@ class Literal::Serializer::UnionType
 		end && (!numeric_ambiguous?(seen) || (has_integer && finite_float_type?(number_member)))
 	end
 
-	private def natural_json_type(type)
-		schema = @context.json_schema(type)
+	private def natural_json_type(type, generator:)
+		schema = @context.json_schema(type, generator:)
+		return unless Hash === schema
+
 		json_type = schema["type"]
 
 		json_type if SafeNaturalJSONTypes.include?(json_type)
@@ -93,12 +95,15 @@ class Literal::UnionSerializer < Literal::Serializer
 
 	attr_reader :type
 
-	def json_schema(type)
-		return constrained_union_json_schema(type) if constrained_union?(type)
+	def value_type(value)
+	end
+
+	def json_schema(type, generator: nil)
+		return constrained_union_json_schema(type, generator:) if constrained_union?(type)
 		return { "type" => "number" } if number_union?(type)
 
 		{
-			"oneOf" => json_schema_members(type),
+			"oneOf" => json_schema_members(type, generator:),
 		}
 	end
 
@@ -145,15 +150,17 @@ class Literal::UnionSerializer < Literal::Serializer
 		end && (!numeric_ambiguous?(seen) || (has_integer && finite_float_type?(number_member)))
 	end
 
-	private def natural_json_type(type)
-		schema = json_schema_for(type)
+	private def natural_json_type(type, generator:)
+		schema = json_schema_for(type, generator:)
+		return unless Hash === schema
+
 		json_type = schema["type"]
 
 		json_type if SafeNaturalJSONTypes.include?(json_type)
 	end
 
-	private def constrained_union_json_schema(type)
-		json_schema(constrained_union(type)).tap do |schema|
+	private def constrained_union_json_schema(type, generator:)
+		json_schema_for(constrained_union(type), generator:).tap do |schema|
 			apply_range_constraints(schema, type.object_constraints.select { |constraint| Range === constraint })
 		end
 	end
@@ -184,12 +191,12 @@ class Literal::UnionSerializer < Literal::Serializer
 			members.any? { |member| finite_float_type?(member) }
 	end
 
-	private def json_schema_members(type)
+	private def json_schema_members(type, generator:)
 		if integer_and_finite_float?(type)
 			type.each.reject { |member| member == Integer || finite_float_type?(member) }
-				.map { |member| json_schema_for(member) } << { "type" => "number" }
+				.map { |member| json_schema_for(member, generator:) } << { "type" => "number" }
 		else
-			type.each.map { |member| json_schema_for(member) }
+			type.each.map { |member| json_schema_for(member, generator:) }
 		end
 	end
 
@@ -219,8 +226,9 @@ class Literal::UnionSerializer < Literal::Serializer
 
 	private def natural_member_type(raw_value, type)
 		json_type = raw_json_type(raw_value)
+		generator = Literal::JSONSchema::Generator.new(@context)
 
-		type.each.find { |member| natural_json_type(member) == json_type } ||
+		type.each.find { |member| natural_json_type(member, generator:) == json_type } ||
 			natural_number_member_type(json_type, type) ||
 			raise(Literal::ArgumentError, "No union member type for JSON type #{json_type.inspect} in #{type.inspect}")
 	end
@@ -228,7 +236,8 @@ class Literal::UnionSerializer < Literal::Serializer
 	private def natural_number_member_type(json_type, type)
 		return unless json_type == "integer"
 
-		type.each.find { |member| natural_json_type(member) == "number" }
+		generator = Literal::JSONSchema::Generator.new(@context)
+		type.each.find { |member| natural_json_type(member, generator:) == "number" }
 	end
 
 	private def raw_json_type(value)

--- a/lib/literal/type.rb
+++ b/lib/literal/type.rb
@@ -13,4 +13,8 @@ module Literal::Type
 			false
 		end
 	end
+
+	def literal_child_types
+		enum_for(__method__) unless block_given?
+	end
 end

--- a/lib/literal/types/array_type.rb
+++ b/lib/literal/types/array_type.rb
@@ -11,6 +11,12 @@ class Literal::Types::ArrayType
 
 	attr_reader :type
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @type
+	end
+
 	def inspect
 		"_Array(#{@type.inspect})"
 	end

--- a/lib/literal/types/class_type.rb
+++ b/lib/literal/types/class_type.rb
@@ -11,6 +11,12 @@ class Literal::Types::ClassType
 
 	attr_reader :type
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @type
+	end
+
 	def inspect
 		"_Class(#{@type.name})"
 	end

--- a/lib/literal/types/constraint_type.rb
+++ b/lib/literal/types/constraint_type.rb
@@ -13,6 +13,13 @@ class Literal::Types::ConstraintType
 	attr_reader :object_constraints
 	attr_reader :property_constraints
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		@object_constraints.each { |type| yield type }
+		@property_constraints.each_value { |type| yield type }
+	end
+
 	def inspect
 		"_Constraint(#{inspect_constraints})"
 	end

--- a/lib/literal/types/deferred_type.rb
+++ b/lib/literal/types/deferred_type.rb
@@ -13,6 +13,13 @@ class Literal::Types::DeferredType
 
 	attr_reader :block
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		type = materialize
+		yield type unless type.equal?(self)
+	end
+
 	def inspect
 		"_Deferred"
 	end

--- a/lib/literal/types/descendant_type.rb
+++ b/lib/literal/types/descendant_type.rb
@@ -10,6 +10,12 @@ class Literal::Types::DescendantType
 
 	attr_reader :type
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @type
+	end
+
 	def inspect
 		"_Descendant(#{@type})"
 	end

--- a/lib/literal/types/enumerable_type.rb
+++ b/lib/literal/types/enumerable_type.rb
@@ -11,6 +11,12 @@ class Literal::Types::EnumerableType
 
 	attr_reader :type
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @type
+	end
+
 	def inspect
 		"_Enumerable(#{@type.inspect})"
 	end

--- a/lib/literal/types/frozen_type.rb
+++ b/lib/literal/types/frozen_type.rb
@@ -17,6 +17,12 @@ class Literal::Types::FrozenType
 
 	attr_reader :type
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @type
+	end
+
 	def inspect
 		"_Frozen(#{@type.inspect})"
 	end

--- a/lib/literal/types/hash_type.rb
+++ b/lib/literal/types/hash_type.rb
@@ -12,6 +12,13 @@ class Literal::Types::HashType
 
 	attr_reader :key_type, :value_type
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @key_type
+		yield @value_type
+	end
+
 	def inspect
 		"_Hash(#{@key_type.inspect}, #{@value_type.inspect})"
 	end

--- a/lib/literal/types/instance_type.rb
+++ b/lib/literal/types/instance_type.rb
@@ -11,6 +11,12 @@ class Literal::Types::InstanceType
 
 	attr_reader :type
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @type
+	end
+
 	def inspect
 		"_Instance(#{@type.name})"
 	end

--- a/lib/literal/types/kind_type.rb
+++ b/lib/literal/types/kind_type.rb
@@ -10,6 +10,12 @@ class Literal::Types::KindType
 
 	attr_reader :type
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @type
+	end
+
 	def ===(object)
 		Literal.subtype?(object, @type)
 	end

--- a/lib/literal/types/map_type.rb
+++ b/lib/literal/types/map_type.rb
@@ -11,6 +11,12 @@ class Literal::Types::MapType
 
 	attr_reader :shape
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		@shape.each_value { |type| yield type }
+	end
+
 	def inspect
 		"_Map(#{@shape.inspect})"
 	end

--- a/lib/literal/types/nilable_type.rb
+++ b/lib/literal/types/nilable_type.rb
@@ -11,6 +11,12 @@ class Literal::Types::NilableType
 
 	attr_reader :type
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @type
+	end
+
 	def inspect
 		"_Nilable(#{@type.inspect})"
 	end

--- a/lib/literal/types/not_type.rb
+++ b/lib/literal/types/not_type.rb
@@ -11,6 +11,12 @@ class Literal::Types::NotType
 
 	attr_reader :type
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @type
+	end
+
 	def inspect
 		"_Not(#{@type.inspect})"
 	end

--- a/lib/literal/types/range_type.rb
+++ b/lib/literal/types/range_type.rb
@@ -11,6 +11,12 @@ class Literal::Types::RangeType
 
 	attr_reader :type
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @type
+	end
+
 	def inspect
 		"_Range(#{@type.inspect})"
 	end

--- a/lib/literal/types/set_type.rb
+++ b/lib/literal/types/set_type.rb
@@ -11,6 +11,12 @@ class Literal::Types::SetType
 
 	attr_reader :type
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @type
+	end
+
 	def inspect
 		"_Set(#{@type.inspect})"
 	end

--- a/lib/literal/types/tagged_union_type.rb
+++ b/lib/literal/types/tagged_union_type.rb
@@ -25,6 +25,12 @@ class Literal::Types::TaggedUnionType
 
 	attr_reader :members
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		@members.each_value { |type| yield type }
+	end
+
 	def inspect
 		pairs = @members.map { |tag, type| "#{tag}: #{type.inspect}" }
 		"_TaggedUnion(#{pairs.join(', ')})"

--- a/lib/literal/types/tuple_type.rb
+++ b/lib/literal/types/tuple_type.rb
@@ -13,6 +13,12 @@ class Literal::Types::TupleType
 
 	attr_reader :types
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		@types.each { |type| yield type }
+	end
+
 	def inspect
 		"_Tuple(#{@types.map(&:inspect).join(', ')})"
 	end

--- a/lib/literal/types/union_type.rb
+++ b/lib/literal/types/union_type.rb
@@ -30,6 +30,12 @@ class Literal::Types::UnionType
 
 	attr_reader :types, :primitives
 
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		@types.each { |type| yield type }
+	end
+
 	def inspect
 		"_Union(#{to_a.map(&:inspect).join(', ')})"
 	end

--- a/test/serialization.test.rb
+++ b/test/serialization.test.rb
@@ -33,6 +33,31 @@ class SerializationDraft < Literal::Data
 	prop? :subtitle, String
 end
 
+class SerializationOrder < Literal::Data
+	prop :id, Integer
+	prop :person, SerializationPerson
+end
+
+SerializationRecursiveAddress = Class.new(Literal::Data) do
+	prop :postcode, String
+end
+
+SerializationRecursiveOrder = Class.new(Literal::Data) do
+	prop :id, Integer
+	prop :address, SerializationRecursiveAddress
+end
+
+SerializationRecursiveAddress.prop :order, SerializationRecursiveOrder
+
+class SerializationRecursiveNode < Literal::Data
+	prop :children, _Array(_Deferred { SerializationRecursiveNode })
+end
+
+class SerializationUnsupportedRecursiveNode < Literal::Data
+	prop :children, _Array(_Deferred { SerializationUnsupportedRecursiveNode })
+	prop :object, Object
+end
+
 class SerializationEnvelope < Literal::Data
 	prop :id, Integer
 	prop :owner, SerializationPerson
@@ -43,24 +68,19 @@ class SerializationEnvelope < Literal::Data
 	prop :payload, _TaggedUnion(hash: _Hash(Symbol, Integer), array: _Array(String))
 end
 
-Example = Literal::SerializationContext.new(
-	Literal::StringSerializer,
-	Literal::SymbolSerializer,
-	Literal::IntegerSerializer,
-	Literal::JSONSchemaNumberSerializer,
-	Literal::FloatSerializer,
-	Literal::BooleanSerializer,
-	Literal::DateSerializer,
-	Literal::StructureSerializer,
-	Literal::TaggedUnionSerializer,
-	Literal::UnionSerializer,
-	Literal::HashSerializer,
-	Literal::MapSerializer,
-	Literal::TupleSerializer,
-	Literal::ArraySerializer,
-	Literal::SetSerializer,
-	Literal::NilableSerializer,
-)
+Example = Literal::SerializationContext.new
+
+test "serialization context includes default serializers" do
+	assert Example.kind === String
+	assert Example.kind === _Hash(Symbol, _JSONData)
+end
+
+test "serialization context defaults can be disabled" do
+	context = Literal::SerializationContext.new(Literal::StringSerializer, defaults: false)
+
+	assert context.kind === String
+	refute context.kind === Integer
+end
 
 test "string length range serialization" do
 	assert_equal(
@@ -105,6 +125,22 @@ test "json schema scalar type serialization" do
 	assert_equal(
 		Example.json_schema(Literal::JSONSchema::Number(exclusive_minimum: 0, maximum: 1.5)),
 		{ "type" => "number", "exclusiveMinimum" => 0, "maximum" => 1.5 },
+	)
+end
+
+test "json data json schema" do
+	assert_equal(
+		Example.json_schema(_JSONData),
+		true,
+	)
+
+	assert_equal(
+		Example.json_schema(_Hash(Symbol, _JSONData)),
+		{
+			"type" => "object",
+			"propertyNames" => { "type" => "string" },
+			"additionalProperties" => true,
+		},
 	)
 end
 
@@ -513,6 +549,71 @@ test "structure json schema" do
 		},
 	)
 
+	person_definition_name = SerializationPerson.name
+	person_definition_ref = "#/$defs/#{person_definition_name.gsub('~', '~0').gsub('/', '~1')}"
+
+	assert_equal(
+		Example.json_schema(SerializationOrder),
+		{
+			"type" => "object",
+			"properties" => {
+				"id" => { "type" => "integer" },
+				"person" => { "$ref" => person_definition_ref },
+			},
+			"required" => ["id", "person"],
+			"additionalProperties" => false,
+			"$defs" => {
+				person_definition_name => {
+					"type" => "object",
+					"properties" => {
+						"name" => { "type" => "string" },
+						"age" => { "type" => "integer" },
+					},
+					"required" => ["name", "age"],
+					"additionalProperties" => false,
+				},
+			},
+		},
+	)
+
+	recursive_order_name = SerializationRecursiveOrder.name
+	recursive_address_name = SerializationRecursiveAddress.name
+	recursive_order_ref = "#/$defs/#{recursive_order_name.gsub('~', '~0').gsub('/', '~1')}"
+	recursive_address_ref = "#/$defs/#{recursive_address_name.gsub('~', '~0').gsub('/', '~1')}"
+
+	assert_equal(
+		Example.json_schema(SerializationRecursiveOrder),
+		{
+			"type" => "object",
+			"properties" => {
+				"id" => { "type" => "integer" },
+				"address" => { "$ref" => recursive_address_ref },
+			},
+			"required" => ["id", "address"],
+			"additionalProperties" => false,
+			"$defs" => {
+				recursive_address_name => {
+					"type" => "object",
+					"properties" => {
+						"postcode" => { "type" => "string" },
+						"order" => { "$ref" => recursive_order_ref },
+					},
+					"required" => ["postcode", "order"],
+					"additionalProperties" => false,
+				},
+				recursive_order_name => {
+					"type" => "object",
+					"properties" => {
+						"id" => { "type" => "integer" },
+						"address" => { "$ref" => recursive_address_ref },
+					},
+					"required" => ["id", "address"],
+					"additionalProperties" => false,
+				},
+			},
+		},
+	)
+
 	assert_equal(
 		Example.json_schema(SerializationBooleanConst),
 		{
@@ -741,6 +842,44 @@ test "nilable serialization roundtrip" do
 	assert_equal(Example.deserialize(nil_serialized, type:), nil)
 end
 
+test "json data serialization roundtrip" do
+	original = {
+		"message" => "ok",
+		"errors" => [
+			{ "prop" => "name", "message" => "is required" },
+		],
+		"count" => 1,
+		"active" => true,
+		"metadata" => nil,
+	}
+
+	serialized = Example.serialize(original, type: _JSONData)
+
+	assert_equal(serialized, original)
+	assert_equal(Example.deserialize(serialized, type: _JSONData), original)
+	assert_raises(Literal::ArgumentError) { Example.serialize({ prop: :name }, type: _JSONData) }
+end
+
+test "hash with json data values serialization roundtrip" do
+	original = {
+		name: "Joel",
+		errors: [{ "prop" => "name", "message" => "is required" }],
+		count: 1,
+	}
+	type = _Hash(Symbol, _JSONData)
+	serialized = Example.serialize(original, type:)
+
+	assert_equal(
+		serialized,
+		{
+			"name" => "Joel",
+			"errors" => [{ "prop" => "name", "message" => "is required" }],
+			"count" => 1,
+		},
+	)
+	assert_equal(Example.deserialize(serialized, type:), original)
+end
+
 test "set serialization roundtrip" do
 	original = Set[1, 2, 3]
 	type = _Set(Integer)
@@ -822,12 +961,48 @@ test "serialization context type matches serializable values" do
 	assert Example.type === [1, 2, 3]
 	assert Example.type === Set[1, 2, 3]
 	assert Example.type === { a: 1, b: 2 }
+	assert Example.type === { "a" => [{ "b" => true }] }
+end
+
+test "serialization context type serializes serializable values" do
+	person = SerializationPerson.new(name: "Joel", age: 42)
+
+	assert_equal(Example.serialize(nil, type: Example.type), nil)
+	assert_equal(Example.serialize("example", type: Example.type), "example")
+	assert_equal(Example.serialize(:example, type: Example.type), "example")
+	assert_equal(Example.serialize(42, type: Example.type), 42)
+	assert_equal(Example.serialize(3.14, type: Example.type), 3.14)
+	assert_equal(Example.serialize(true, type: Example.type), true)
+	assert_equal(Example.serialize(Date.new(2025, 1, 13), type: Example.type), "2025-01-13")
+	assert_equal(Example.serialize([:a, 1, nil], type: Example.type), ["a", 1, nil])
+	assert_equal(Example.serialize({ a: 1, b: :two }, type: Example.type), [["a", 1], ["b", "two"]])
+	assert_equal(Example.serialize({ "a" => "b" }, type: Example.type), [["a", "b"]])
+	assert_equal(Example.serialize(Set[:a, :b], type: Example.type), ["a", "b"])
+	assert_equal(Example.serialize(person, type: Example.type), { "name" => "Joel", "age" => 42 })
 end
 
 test "recursive kind support" do
 	assert Example.kind === _TaggedUnion(foo: Example.type, bar: String)
 	assert Example.kind === _Array(Example.type)
 	assert Example.kind === _Set(Example.type)
+	assert Example.kind === SerializationRecursiveOrder
+	assert Example.kind === SerializationRecursiveNode
+end
+
+test "recursive serializable types must loop through named structures" do
+	recursive_array = nil
+	recursive_array = _Deferred { _Array(recursive_array) }
+	anonymous_node = Class.new(Literal::Data)
+
+	anonymous_node.prop :child, anonymous_node
+
+	refute Example.kind === recursive_array
+	refute Example.kind === anonymous_node
+	refute Example.kind === SerializationUnsupportedRecursiveNode
+
+	assert_raises(Literal::ArgumentError) { Example.json_schema(recursive_array) }
+	assert_raises(Literal::ArgumentError) { Example.json_schema(anonymous_node) }
+	assert_raises(Literal::ArgumentError) { Example.json_schema(SerializationUnsupportedRecursiveNode) }
 end
 
 test "union serialization roundtrip" do

--- a/test/types/literal_child_types.test.rb
+++ b/test/types/literal_child_types.test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+include Literal::Types
+
+test "default literal child types" do
+	assert_equal _Any.literal_child_types.to_a, []
+end
+
+test "single child literal types" do
+	assert_equal _Array(String).literal_child_types.to_a, [String]
+	assert_equal _Enumerable(String).literal_child_types.to_a, [String]
+	assert_equal _Frozen(String).literal_child_types.to_a, [String]
+	assert_equal _Kind(String).literal_child_types.to_a, [String]
+	assert_equal _Nilable(String).literal_child_types.to_a, [String]
+	assert_equal _Not(String).literal_child_types.to_a, [String]
+	assert_equal _Range(String).literal_child_types.to_a, [String]
+	assert_equal _Set(String).literal_child_types.to_a, [String]
+end
+
+test "compound literal child types" do
+	assert_equal _Hash(Symbol, Integer).literal_child_types.to_a, [Symbol, Integer]
+	assert_equal _Map(name: String, age: Integer).literal_child_types.to_a, [String, Integer]
+	assert_equal _Tuple(String, Integer).literal_child_types.to_a, [String, Integer]
+	assert_equal _Union(String, Integer, "literal").literal_child_types.to_a, [String, Integer]
+	assert_equal _TaggedUnion(name: String, age: Integer).literal_child_types.to_a, [String, Integer]
+end
+
+test "constraint literal child types" do
+	assert_equal _Constraint(String, 1..10, size: 1..5).literal_child_types.to_a, [String, 1..10, 1..5]
+end
+
+test "deferred literal child types" do
+	type = _Deferred { String }
+
+	assert_equal type.literal_child_types.to_a, [String]
+end
+
+test "data structure literal child types" do
+	data = Class.new(Literal::Data) do
+		prop :name, String
+		prop :age, Integer
+	end
+
+	struct = Class.new(Literal::Struct) do
+		prop :name, String
+		prop :age, Integer
+	end
+
+	assert_equal data.literal_child_types.to_a, [String, Integer]
+	assert_equal struct.literal_child_types.to_a, [String, Integer]
+end


### PR DESCRIPTION
## Summary

This branch adds recursive JSON Schema generation for Literal serialization contexts.

The main change is that schema generation now carries a `Literal::JSONSchema::Generator` through recursive calls. That lets us detect nested structure types, emit them once under `$defs`, and reference them with `$ref` instead of infinitely expanding object schemas.

Definition names are intentionally opaque per-schema indexes (`"0"`, `"1"`, ... using base36) rather than data structure constant names. They only need to be stable within a single generated schema, and this avoids leaking Ruby class names into JSON Schema output.

## What Changed

- Added `Literal::JSONSchema::Generator` to own schema-generation state for a single root schema.
- Threaded the generator through serializer `json_schema` calls instead of using hidden global/thread state.
- Added `$defs`/`$ref` support for named `Literal::DataStructure` classes.
- Added recursive structure support, including mutually recursive structures.
- Added opaque per-schema `$defs` names instead of exposing data structure names.
- Added `literal_child_types` so Literal types and data structures can expose their type graph.
- Added serializable graph validation so recursive types are only accepted when they can be represented safely.
- Added default serializers to `Literal::SerializationContext.new`, with custom serializers ordered before defaults.
- Added `_JSONData` as an identity JSON blob serializer, ordered last as a fallback.

## Examples

Nested structures now use `$defs`:

```ruby
class Person < Literal::Data
  prop :name, String
  prop :age, Integer
end

class Order < Literal::Data
  prop :id, Integer
  prop :person, Person
end

context = Literal::SerializationContext.new
context.json_schema(Order)
```

Produces an inline `Order` schema with `person` as an opaque reference:

```ruby
{
  "type" => "object",
  "properties" => {
    "id" => { "type" => "integer" },
    "person" => { "$ref" => "#/$defs/0" },
  },
  "required" => ["id", "person"],
  "additionalProperties" => false,
  "$defs" => {
    "0" => {
      "type" => "object",
      "properties" => {
        "name" => { "type" => "string" },
        "age" => { "type" => "integer" },
      },
      "required" => ["name", "age"],
      "additionalProperties" => false,
    },
  },
}
```

Recursive structures can now be represented safely:

```ruby
class Node < Literal::Data
  prop :children, _Array(_Deferred { Node })
end

context.json_schema(Node)
# children.items uses { "$ref" => "#/$defs/0" }
# Node is emitted once under "$defs" with an opaque key.
```

Mutually recursive structures are also supported:

```ruby
class Order < Literal::Data
  prop :id, Integer
end

class Address < Literal::Data
  prop :postcode, String
  prop :order, Order
end

Order.prop :address, Address

context.json_schema(Order)
# Order references Address through "#/$defs/0".
# Address references Order through "#/$defs/1".
```

Recursive graphs that cannot be represented with stable references are rejected:

```ruby
recursive_array = nil
recursive_array = _Deferred { _Array(recursive_array) }

context.json_schema(recursive_array)
# raises Literal::ArgumentError
```

## Notes

`Literal::SerializationContext.new` now includes the built-in serializers by default. This gives the recursive schema generator a consistent serializer order, including `JSONDataSerializer` last so more specific serializers win first.

`_JSONData` is handled as an already-JSON blob:

```ruby
context.json_schema(_JSONData)
# => true
```

## Tests

```sh
mise run test
```
