### PR TITLE
Let types know what their constant name is

### DIFF
--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -23,6 +23,14 @@ module Literal
 		loader.setup
 	end
 
+	def self.const_name(object)
+		const_ref(object).first&.name
+	end
+
+	def self.const_ref(object)
+		ConstantTracker::CONSTANTS[object] || []
+	end
+
 	def self.Value(*args, **kwargs, &block)
 		value_class = Class.new(Literal::Value)
 
@@ -204,5 +212,7 @@ module Literal
 		end
 	end
 end
+
+Module.prepend(Literal::ConstantTracker)
 
 require_relative "literal/railtie" if defined?(Rails)

--- a/lib/literal/constant_tracker.rb
+++ b/lib/literal/constant_tracker.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Literal::ConstantTracker
+	CONSTANTS = ObjectSpace::WeakKeyMap.new
+
+	Reference = Data.define(:owner, :const) do
+		def name
+			if owner == Object
+				const.to_s
+			elsif owner.name
+				"#{owner.name}::#{const}"
+			else
+				"#<anonymous #{owner.class}>::#{const}"
+			end
+		end
+
+		alias_method :to_s, :name
+	end
+
+	def const_added(const)
+		return super if autoload?(const, false)
+
+		begin
+			object = const_get(const, false)
+		rescue ::NameError
+			return super
+		end
+
+		begin
+			(CONSTANTS[object] ||= []) << Reference.new(self, const)
+		rescue ::ArgumentError
+			return super
+			# object is not weak-keyable: integer, symbol, true, false, nil, etc.
+		end
+
+		super
+	end
+end

--- a/lib/literal/failure.rb
+++ b/lib/literal/failure.rb
@@ -19,6 +19,10 @@ class Literal::Failure < Literal::Result
 			"Literal::Failure(#{@type.inspect})"
 		end
 
+		def name
+			Literal.const_name(self)
+		end
+
 		freeze
 	end
 

--- a/lib/literal/result/generic.rb
+++ b/lib/literal/result/generic.rb
@@ -21,6 +21,10 @@ class Literal::Result::Generic
 		end
 	end
 
+	def name
+		Literal.const_name(self)
+	end
+
 	def try
 		raise ArgumentError unless block_given?
 

--- a/lib/literal/success.rb
+++ b/lib/literal/success.rb
@@ -19,6 +19,10 @@ class Literal::Success < Literal::Result
 			"Literal::Success(#{@type.inspect})"
 		end
 
+		def name
+			Literal.const_name(self)
+		end
+
 		freeze
 	end
 

--- a/lib/literal/type.rb
+++ b/lib/literal/type.rb
@@ -17,4 +17,8 @@ module Literal::Type
 	def literal_child_types
 		enum_for(__method__) unless block_given?
 	end
+
+	def name
+		Literal.const_name(self)
+	end
 end


### PR DESCRIPTION
This PR introduces a constant tracker that allows types to know their own constant name, like a class would know its own name.