### PR TITLE
Enum serializer fixes2

### DIFF
--- a/lib/literal/serializers/enum_serializer.rb
+++ b/lib/literal/serializers/enum_serializer.rb
@@ -7,6 +7,14 @@ class Literal::EnumSerializer < Literal::Serializer
     [backing_type(type)]
   end
 
+  def json_type(type)
+    json_type_for(backing_type(type))
+  end
+
+  def value_type(value)
+    value.class if Literal::Enum === value
+  end
+
   def json_schema(type, generator: nil)
     backing = backing_type(type)
     values = type.values.map { |value| serialize_contents(value, type: backing) }

--- a/test/serialization.test.rb
+++ b/test/serialization.test.rb
@@ -2702,3 +2702,52 @@ test "a structure carrying an unserializable enum is not serializable" do
 	refute Example.kind === holder
 	assert_raises(Literal::ArgumentError) { Example.json_schema(holder) }
 end
+
+test "an enum member is serializable through the context's aggregate type" do
+	assert Example.type === SerializationPriority::Medium
+
+	serialized = Example.serialize(SerializationPriority::Medium, type: Example.type)
+
+	assert_equal(serialized, 2)
+end
+
+test "enum in a union with a distinguishable type roundtrips" do
+	type = _Union(SerializationPriority, String)
+
+	member_serialized = Example.serialize(SerializationPriority::High, type:)
+	string_serialized = Example.serialize("none", type:)
+
+	assert_equal(member_serialized, 3)
+	assert_equal(string_serialized, "none")
+	assert_equal(Example.deserialize(member_serialized, type:), SerializationPriority::High)
+	assert_equal(Example.deserialize(string_serialized, type:), "none")
+end
+
+test "enum in a union json schema nests the enum schema as a member" do
+	assert_equal(
+		Example.json_schema(_Union(SerializationPriority, String)),
+		{
+			"oneOf" => [
+				{ "type" => "integer", "enum" => [1, 2, 3] },
+				{ "type" => "string" },
+			],
+		},
+	)
+end
+
+test "an enum that collides with a sibling union member is rejected" do
+	error = assert_raises(Literal::ArgumentError) do
+		Example.json_schema(_Union(SerializationSuit, String))
+	end
+
+	assert error.message.include?("SerializationSuit")
+	assert error.message.include?("String")
+end
+
+test "serializing a value that is not a member of the enum raises" do
+	assert_raises(Literal::ArgumentError) { Example.serialize("red", type: SerializationSuit) }
+end
+
+test "deserializing a value outside the enum raises" do
+	assert_raises(ArgumentError) { Example.deserialize("green", type: SerializationSuit) }
+end


### PR DESCRIPTION
Fixes issues in https://github.com/yippee-fun/literal/pull/364

1. value_type — aggregate-type serialization crashed
- `Example.serialize(member, type: Example.type)` raised `NoMethodError` even though `Example.type === member` said it was serializable.
- Cause: inherited `value_type` returned the base `Literal::Enum` class, whose `backing_type` lookup fails (no `:value` prop).
- Fix: `def value_type(value) = value.class if Literal::Enum === value` — returns the concrete enum class.

2. json_type — enums couldn't be used in a `_Union`
- `_Union(SomeEnum, Integer)` raised instead of working.
- Cause: enum reported nil json type, so union discrimination couldn't place it.
- Fix: `def json_type(type) = json_type_for(backing_type(type))` — delegates to the backing type. Now enums round-trip in unions, produce clean oneOf schemas, and give proper ambiguity errors when they collide (e.g. Symbol-backed enum vs String).