### PR TITLE
Coercions, seals, and nested drafts

### DIFF
--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -79,9 +79,29 @@ module Literal
 		end
 	end
 
+	# Returns the canonical draft class for the given class at its current
+	# shape: repeated calls return the same class until the drafted class's
+	# properties change, at which point a fresh draft class is generated and
+	# the stale one becomes collectable.
 	def self.Draft(type)
-		Class.new(Literal::Draft) do
-			__draft__(type)
+		unless Literal::Properties === type
+			raise Literal::ArgumentError.new("Literal::Draft requires a class that extends Literal::Properties.")
+		end
+
+		schema = type.literal_properties
+		snapshot = schema.snapshot
+		cached = Literal::Draft::CACHE[schema]
+
+		if cached && snapshot.equal?(cached[0])
+			cached[1]
+		else
+			draft = Class.new(Literal::Draft) do
+				__draft__(type)
+			end
+
+			Literal::Draft::CACHE[schema] = [snapshot, draft].freeze
+
+			draft
 		end
 	end
 

--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -84,6 +84,14 @@ module Literal
 		end
 	end
 
+	def self.Coercion(&block)
+		Literal::Coercion.new(&block)
+	end
+
+	def self.Seal(&block)
+		Literal::Seal.new(&block)
+	end
+
 	def self.Array(type)
 		Literal::Array::Generic.new(type)
 	end

--- a/lib/literal.rb
+++ b/lib/literal.rb
@@ -5,6 +5,7 @@ require_relative "literal/version"
 
 module Literal
 	OBJECT_ID = BasicObject.instance_method(:__id__)
+	FROZEN = Kernel.instance_method(:frozen?)
 
 	Loader = Zeitwerk::Loader.for_gem.tap do |loader|
 		loader.ignore("#{__dir__}/literal/kernel.rb")

--- a/lib/literal/array.rb
+++ b/lib/literal/array.rb
@@ -21,6 +21,7 @@
 class Literal::Array
 	class Generic
 		include Literal::Type
+		include Literal::Coercions::Composable
 
 		def initialize(type)
 			@type = type

--- a/lib/literal/coercion.rb
+++ b/lib/literal/coercion.rb
@@ -95,6 +95,9 @@ class Literal::Coercion
 	end
 
 	def __compose__(first, second)
-		proc { |value| second.call(first.call(value)) }
+		# instance_exec, not call: coercions run against the object being
+		# constructed, and each stage should see that context the same way an
+		# uncomposed block would.
+		proc { |value| instance_exec(instance_exec(value, &first), &second) }
 	end
 end

--- a/lib/literal/coercion.rb
+++ b/lib/literal/coercion.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# A composable input coercion. Wraps a callable that normalizes input before
+# the type check. Coercions run at the input boundaries — the initializer,
+# writers, and draft assignment — and never on final-value paths like
+# `from_props` or `marshal_load`.
+#
+# Compose with `>>` and `<<`: composing two coercions returns a coercion, and
+# composing with a `Literal::Seal` returns a seal whose coercion runs first.
+# A coercion can never come after a seal.
+#
+# Construct with `Literal::Coercion(&block)`.
+class Literal::Coercion
+	class << self
+		def [](...)
+			new(...)
+		end
+	end
+
+	def initialize(callable = nil, &block)
+		callable ||= block
+
+		unless callable
+			raise Literal::ArgumentError.new("Literal::Coercion requires a callable or a block.")
+		end
+
+		@callable = __proc_from__(callable)
+
+		pipeline = self
+		@proc = proc { |value| pipeline.call(value) }
+		@proc.define_singleton_method(:__literal_pipeline__) { pipeline }
+
+		freeze
+	end
+
+	# The coercion as a Proc, for property definitions — `prop :name, String, &NilIfEmpty`.
+	# The returned proc carries a reference back to this object, so `prop` can
+	# recover the pipeline structure.
+	def to_proc
+		@proc
+	end
+
+	def call(value)
+		@callable.call(value)
+	end
+
+	def coercion_proc
+		@callable
+	end
+
+	def seal_proc
+		nil
+	end
+
+	def >>(other)
+		other = other.__literal_pipeline__ if other.respond_to?(:__literal_pipeline__)
+
+		case other
+		when Literal::Seal
+			Literal::Seal.new(
+				other.seal_proc,
+				coercion: (coercion = other.coercion_proc) ? __compose__(@callable, coercion) : @callable,
+			)
+		when Literal::Coercion
+			Literal::Coercion.new(__compose__(@callable, other.coercion_proc))
+		else
+			Literal::Coercion.new(__compose__(@callable, __proc_from__(other)))
+		end
+	end
+
+	def <<(other)
+		other = other.__literal_pipeline__ if other.respond_to?(:__literal_pipeline__)
+
+		case other
+		when Literal::Seal
+			raise Literal::ArgumentError.new(
+				"A coercion cannot run after a seal. Compose as `coercion >> seal` or `seal << coercion` instead.",
+			)
+		when Literal::Coercion
+			Literal::Coercion.new(__compose__(other.coercion_proc, @callable))
+		else
+			Literal::Coercion.new(__compose__(__proc_from__(other), @callable))
+		end
+	end
+
+	private
+
+	def __proc_from__(callable)
+		case callable
+		when ::Proc
+			callable
+		else
+			callable.respond_to?(:to_proc) ? callable.to_proc : proc { |value| callable.call(value) }
+		end
+	end
+
+	def __compose__(first, second)
+		proc { |value| second.call(first.call(value)) }
+	end
+end

--- a/lib/literal/coercions.rb
+++ b/lib/literal/coercions.rb
@@ -3,17 +3,17 @@
 module Literal::Coercions
 	# Shallow: freezes a copy, so the caller’s object is never mutated.
 	# References held by the value (array elements, hash values) stay mutable.
-	Immutable = proc { |it| it.frozen? ? it : it.dup.freeze }
+	Immutable = Literal::Seal { |it| it.frozen? ? it : it.dup.freeze }
 
 	# Deep: makes the value Ractor-shareable, freezing the entire object graph.
 	# Works on a deep copy, so the caller’s object is never mutated. Raises
 	# Ractor::IsolationError for values that cannot be made shareable (IO,
 	# Thread, procs capturing mutable state).
-	DeepImmutable = proc do |it|
+	DeepImmutable = Literal::Seal { |it|
 		Ractor.shareable?(it) ? it : Ractor.make_shareable(it, copy: true)
-	end
+	}
 
 	# Converts empty values ("", [], {}) to nil, for optional properties where
 	# empty input means absent. Everything else passes through untouched.
-	NilIfEmpty = proc { |it| (it.respond_to?(:empty?) && it.empty?) ? nil : it }
+	NilIfEmpty = Literal::Coercion { |it| (it.respond_to?(:empty?) && it.empty?) ? nil : it }
 end

--- a/lib/literal/coercions/composable.rb
+++ b/lib/literal/coercions/composable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Coercion composition for objects that act as coercions via #to_proc, such
+# as collection generics — `Literal::Array(String) >> Immutable`.
+module Literal::Coercions::Composable
+	def >>(other)
+		Literal::Coercion(&to_proc) >> other
+	end
+
+	def <<(other)
+		Literal::Coercion(&to_proc) << other
+	end
+end

--- a/lib/literal/data_structure.rb
+++ b/lib/literal/data_structure.rb
@@ -116,19 +116,23 @@ class Literal::DataStructure
 			attributes[name].freeze if attributes.key?(name)
 		end
 
-		__literal_assign_props__(attributes, "#marshal_load")
+		# Seals don't apply here: they belong to construction, and a loaded
+		# object was constructed — and sealed — before it was dumped. The
+		# frozen state recorded at dump is what gets restored.
+		__literal_assign_props__(attributes, "#marshal_load", seal: false)
 
 		freeze if was_frozen
 	end
 
 	# Assign final property values from a Hash keyed by Symbol property name,
-	# type checking each value but never coercing. Seals still apply — they
-	# fix a value's final representation, not its input. Missing properties
-	# resolve the same way an omitted initializer parameter would. Keys that
-	# don't match a property are ignored — for marshalling, they're values
-	# for properties that have since been removed. Returns the number of keys
-	# that matched a property so callers can be stricter.
-	private def __literal_assign_props__(props, method_name)
+	# type checking each value but never coercing. Seals apply unless the
+	# caller is restoring already-constructed state — they fix a value's
+	# final representation, not its input. Missing properties resolve the
+	# same way an omitted initializer parameter would. Keys that don't match
+	# a property are ignored — for marshalling, they're values for properties
+	# that have since been removed. Returns the number of keys that matched a
+	# property so callers can be stricter.
+	private def __literal_assign_props__(props, method_name, seal: true)
 		properties = self.class.literal_properties
 		matched = 0
 
@@ -142,8 +146,8 @@ class Literal::DataStructure
 				value = self.class.__send__(:missing_prop_value, property, self)
 			end
 
-			if (seal = property.seal)
-				value = seal.call(value)
+			if seal && (property_seal = property.seal)
+				value = property_seal.call(value)
 			end
 
 			Literal.check(value, property.type) do |context|

--- a/lib/literal/data_structure.rb
+++ b/lib/literal/data_structure.rb
@@ -100,7 +100,14 @@ class Literal::DataStructure
 
 	# required method for Marshal compatibility
 	def marshal_load(payload)
-		_version, attributes, was_frozen = payload
+		_version, attributes, was_frozen, frozen_values = payload
+
+		# Marshal.load rebuilds contained objects unfrozen, so restore the
+		# frozen state each value had when it was dumped — before the type
+		# check, which may require it. Version 1 payloads carry no list.
+		frozen_values&.each do |name|
+			attributes[name].freeze if attributes.key?(name)
+		end
 
 		__literal_assign_props__(attributes, "#marshal_load")
 
@@ -144,7 +151,20 @@ class Literal::DataStructure
 
 	# required method for Marshal compatibility
 	def marshal_dump
-		[1, to_h, frozen?].freeze
+		attributes = to_h
+
+		# Record which values are frozen so marshal_load can restore that
+		# state. Immediates are skipped — they always load frozen anyway.
+		frozen_values = attributes.keys.select do |name|
+			case (value = attributes[name])
+			when Integer, Float, Symbol, nil, true, false
+				false
+			else
+				Literal::FROZEN.bind_call(value)
+			end
+		end
+
+		[2, attributes, frozen?, frozen_values.freeze].freeze
 	end
 
 	def hash

--- a/lib/literal/data_structure.rb
+++ b/lib/literal/data_structure.rb
@@ -5,6 +5,13 @@ class Literal::DataStructure
 	extend Literal::Properties
 
 	class << self
+		# Build an instance through a draft: yields a draft of this class to
+		# the block, then finalizes it. Any arguments are passed through to
+		# the draft's constructor.
+		def build(...)
+			Literal::Draft(self).build(...)
+		end
+
 		def literal_child_types
 			return enum_for(__method__) unless block_given?
 

--- a/lib/literal/data_structure.rb
+++ b/lib/literal/data_structure.rb
@@ -108,10 +108,11 @@ class Literal::DataStructure
 	end
 
 	# Assign final property values from a Hash keyed by Symbol property name,
-	# type checking each value but never coercing. Missing properties resolve
-	# the same way an omitted initializer parameter would. Keys that don't
-	# match a property are ignored — for marshalling, they're values for
-	# properties that have since been removed. Returns the number of keys
+	# type checking each value but never coercing. Seals still apply — they
+	# fix a value's final representation, not its input. Missing properties
+	# resolve the same way an omitted initializer parameter would. Keys that
+	# don't match a property are ignored — for marshalling, they're values
+	# for properties that have since been removed. Returns the number of keys
 	# that matched a property so callers can be stricter.
 	private def __literal_assign_props__(props, method_name)
 		properties = self.class.literal_properties
@@ -125,6 +126,10 @@ class Literal::DataStructure
 				value = props[name]
 			else
 				value = self.class.__send__(:missing_prop_value, property, self)
+			end
+
+			if (seal = property.seal)
+				value = seal.call(value)
 			end
 
 			Literal.check(value, property.type) do |context|

--- a/lib/literal/draft.rb
+++ b/lib/literal/draft.rb
@@ -64,16 +64,92 @@ class Literal::Draft < Literal::Struct
 
 			prop(
 				property.name,
-				Literal::Types._Union(property.type, Literal::Undefined),
+				Literal::Types._Union(__relax__(property.type), Literal::Undefined),
 				property.kind,
 				predicate: property.predicate,
 				default: Literal::Undefined,
 				description: property.description,
 				&(original_coercion && proc { |value|
-					(Literal::Undefined == value) ? value : instance_exec(value, &original_coercion)
+					# Coercions normalize input for the drafted type. Unset slots and
+					# nested drafts aren't that input yet — the draft meets the
+					# coercion's output contract at finalize, through its own
+					# construction — so both pass through untouched.
+					if Literal::Undefined == value || Literal::Draft === value
+						value
+					else
+						instance_exec(value, &original_coercion)
+					end
 				})
 			)
 		end
+
+		# Drafts relax the drafted type's requirements while a value is being
+		# built up: representation — a _Frozen constraint doesn't bind draft
+		# state — and finality — a slot typed as a Literal::Properties class
+		# also accepts a draft of it. Finalizing re-imposes both through the
+		# drafted type's own construction.
+		private def __relax__(type)
+			case type
+			when Literal::Types::FrozenType
+				__relax__(type.type)
+			when Literal::Types::NilableType
+				Literal::Types._Nilable(__relax__(type.type))
+			when Literal::Types::UnionType
+				Literal::Types._Union(*type.types.map { |member| __relax__(member) }, *type.primitives)
+			when Literal::Properties
+				# A slot typed as a draft class already holds draft state; only
+				# final types get widened.
+				if Class === type && type <= Literal::Draft
+					type
+				else
+					Literal::Types._Union(type, Literal::Draft::Type.new(type))
+				end
+			else
+				type
+			end
+		end
+	end
+
+	# Matches any draft whose drafted type is a subtype of the given type —
+	# what `Literal::Draft(type).===` matches, without generating a draft
+	# class. Relaxed draft slots use this as their union member, which keeps
+	# recursive types (a Person with a Person property) from recursing forever
+	# at draft-class definition.
+	class Type
+		include Literal::Type
+
+		def initialize(type)
+			@type = type
+			freeze
+		end
+
+		attr_reader :type
+
+		def inspect
+			"Literal::Draft(#{@type.inspect})"
+		end
+
+		def ===(value)
+			Literal::Draft === value && (drafted = value.class.__type__) &&
+				Literal.subtype?(drafted, @type)
+		end
+
+		def >=(other, context: nil)
+			case other
+			when Literal::Draft::Type
+				Literal.subtype?(other.type, @type, context:)
+			when Class
+				if other <= Literal::Draft && (drafted = other.__type__)
+					Literal.subtype?(drafted, @type, context:)
+				else
+					false
+				end
+			else
+				false
+			end
+		end
+
+		freeze
 	end
 
 	# Build the drafted type from the properties that have been set. The
@@ -81,6 +157,11 @@ class Literal::Draft < Literal::Struct
 	# properties are enforced here. Any properties passed here are assigned
 	# to the draft first — through its writers, so they're coerced and type
 	# checked like any other assignment.
+	#
+	# Nested drafts finalize too, depth-first — unless the drafted type's
+	# property accepts the draft as-is, in which case the slot wanted a draft
+	# and it stays one. The draft itself is never mutated: finalizing twice
+	# builds two independent values.
 	def finalize(**props)
 		type = self.class.__type__
 
@@ -90,6 +171,19 @@ class Literal::Draft < Literal::Struct
 
 		props.each { |name, value| self[name] = value }
 
-		type.from_props(to_h.reject { |_, value| Literal::Undefined == value })
+		properties = type.literal_properties
+		attributes = {}
+
+		to_h.each do |name, value|
+			next if Literal::Undefined == value
+
+			if Literal::Draft === value && !(properties[name].type === value)
+				value = value.finalize
+			end
+
+			attributes[name] = value
+		end
+
+		type.from_props(attributes)
 	end
 end

--- a/lib/literal/draft.rb
+++ b/lib/literal/draft.rb
@@ -81,7 +81,7 @@ class Literal::Draft < Literal::Struct
 				# Undefined first: union members are tried in order, and matching
 				# the unset sentinel by identity keeps deferred types in the
 				# relaxed member from materializing before a real value arrives.
-				Literal::Types._Union(Literal::Undefined, __relax__(property.type)),
+				Literal::Types._Union(Literal::Undefined, Literal::Types._DraftState(property.type)),
 				property.kind,
 				predicate: property.predicate,
 				default: Literal::Undefined,
@@ -100,35 +100,6 @@ class Literal::Draft < Literal::Struct
 			)
 		end
 
-		# Drafts relax the drafted type's requirements while a value is being
-		# built up: representation — a _Frozen constraint doesn't bind draft
-		# state — and finality — a slot typed as a Literal::Properties class
-		# also accepts a draft of it. Finalizing re-imposes both through the
-		# drafted type's own construction.
-		private def __relax__(type)
-			case type
-			when Literal::Types::DeferredType
-				# Wrapped rather than materialized: the deferred constant may not
-				# be defined yet at draft-definition time.
-				Literal::Types::DeferredType.new { __relax__(type.materialize) }
-			when Literal::Types::FrozenType
-				__relax__(type.type)
-			when Literal::Types::NilableType
-				Literal::Types._Nilable(__relax__(type.type))
-			when Literal::Types::UnionType
-				Literal::Types._Union(*type.types.map { |member| __relax__(member) }, *type.primitives)
-			when Literal::Properties
-				# A slot typed as a draft class already holds draft state; only
-				# final types get widened.
-				if Class === type && type <= Literal::Draft
-					type
-				else
-					Literal::Types._Union(type, Literal::Draft::Type.new(type))
-				end
-			else
-				type
-			end
-		end
 	end
 
 	# Matches any draft whose drafted type is a subtype of the given type —

--- a/lib/literal/draft.rb
+++ b/lib/literal/draft.rb
@@ -5,6 +5,14 @@
 # hold Literal::Undefined, so an explicit nil is distinguishable from "not
 # provided yet". Create a draft class with `Literal::Draft(SomeType)`.
 class Literal::Draft < Literal::Struct
+	# Draft classes keyed by the drafted class's schema — see Literal.Draft.
+	# The schema, not its snapshot: WeakKeyMap compares keys with eql?, and a
+	# subclass's snapshot is eql? to its parent's, while schemas are one per
+	# class and compare by identity. Each entry holds [snapshot, draft] so a
+	# schema change (snapshot identity change) reads as a miss. The key is
+	# weak: when a class is collected, its schema and cached draft follow.
+	CACHE = ObjectSpace::WeakKeyMap.new
+
 	class << self
 		# Generated draft classes override this with the class they draft.
 		def __type__

--- a/lib/literal/draft.rb
+++ b/lib/literal/draft.rb
@@ -64,7 +64,10 @@ class Literal::Draft < Literal::Struct
 
 			prop(
 				property.name,
-				Literal::Types._Union(__relax__(property.type), Literal::Undefined),
+				# Undefined first: union members are tried in order, and matching
+				# the unset sentinel by identity keeps deferred types in the
+				# relaxed member from materializing before a real value arrives.
+				Literal::Types._Union(Literal::Undefined, __relax__(property.type)),
 				property.kind,
 				predicate: property.predicate,
 				default: Literal::Undefined,
@@ -90,6 +93,10 @@ class Literal::Draft < Literal::Struct
 		# drafted type's own construction.
 		private def __relax__(type)
 			case type
+			when Literal::Types::DeferredType
+				# Wrapped rather than materialized: the deferred constant may not
+				# be defined yet at draft-definition time.
+				Literal::Types::DeferredType.new { __relax__(type.materialize) }
 			when Literal::Types::FrozenType
 				__relax__(type.type)
 			when Literal::Types::NilableType

--- a/lib/literal/draft.rb
+++ b/lib/literal/draft.rb
@@ -19,6 +19,12 @@ class Literal::Draft < Literal::Struct
 			nil
 		end
 
+		# Build a finalized value in one call: constructs a draft (passing any
+		# arguments through), yields it to the block, and finalizes it.
+		def build(*args, **kwargs, &block)
+			new(*args, **kwargs).finalize(&block)
+		end
+
 		# Draft classes are types: any draft of a subtype of our drafted type
 		# matches, regardless of which Literal::Draft() call built its class.
 		def ===(value)
@@ -175,8 +181,12 @@ class Literal::Draft < Literal::Struct
 	#
 	# Nested drafts finalize too, depth-first — unless the drafted type's
 	# property accepts the draft as-is, in which case the slot wanted a draft
-	# and it stays one. The draft itself is never mutated: finalizing twice
-	# builds two independent values.
+	# and it stays one. The draft itself is never mutated by building: aside
+	# from any props and block given here, finalizing twice builds two
+	# independent values.
+	#
+	# A block receives the draft after any props are assigned and before the
+	# value is built — for last touches like conditional assignment.
 	def finalize(**props)
 		type = self.class.__type__
 
@@ -185,6 +195,8 @@ class Literal::Draft < Literal::Struct
 		end
 
 		props.each { |name, value| self[name] = value }
+
+		yield self if block_given?
 
 		properties = type.literal_properties
 		attributes = {}

--- a/lib/literal/hash.rb
+++ b/lib/literal/hash.rb
@@ -22,6 +22,7 @@
 class Literal::Hash
 	class Generic
 		include Literal::Type
+		include Literal::Coercions::Composable
 
 		def initialize(key_type, value_type)
 			@key_type = key_type

--- a/lib/literal/properties.rb
+++ b/lib/literal/properties.rb
@@ -21,11 +21,21 @@ module Literal::Properties
 	end
 
 	def prop(name, type, kind = :keyword, reader: false, writer: false, predicate: false, default: nil, description: nil, &coercion)
+		seal = nil
+
+		# A block built from a Literal::Coercion or Literal::Seal carries its
+		# pipeline structure, which splits into the property's two slots.
+		if coercion&.respond_to?(:__literal_pipeline__)
+			pipeline = coercion.__literal_pipeline__
+			coercion = pipeline.coercion_proc
+			seal = pipeline.seal_proc
+		end
+
 		if default && !(Proc === default || default.frozen?)
 			raise Literal::ArgumentError.new("The default must be a frozen object or a Proc.")
 		end
 
-		if !default.nil? && !(Proc === default) && !coercion && !(Literal::Types::DeferredType === type) && !(type === default)
+		if !default.nil? && !(Proc === default) && !coercion && !seal && !(Literal::Types::DeferredType === type) && !(type === default)
 			raise Literal::ArgumentError.new("The default for #{name.inspect} must match its type.")
 		end
 
@@ -96,6 +106,7 @@ module Literal::Properties
 			default:,
 			description:,
 			coercion:,
+			seal:,
 		)
 
 		literal_properties << property

--- a/lib/literal/properties/schema.rb
+++ b/lib/literal/properties/schema.rb
@@ -12,6 +12,14 @@ class Literal::Properties::Schema
 
 	attr_reader :properties_index
 
+	# The current sorted properties array. Its object identity changes if and
+	# only if the schema changes — `<<` replaces the array rather than
+	# mutating it, and `dup` copies it — so it can key caches of anything
+	# derived from the schema, such as generated draft classes.
+	def snapshot
+		@sorted_properties
+	end
+
 	def [](key)
 		@properties_index[key]
 	end
@@ -21,6 +29,8 @@ class Literal::Properties::Schema
 			@properties_index[value.name] = value
 			# ruby's sort is unstable, this trick makes it stable
 			n = 0
+			# Replacing (not mutating) the array is a contract: `snapshot`
+			# relies on its identity changing with every schema change.
 			@sorted_properties = @properties_index.values.sort_by! { |it| n += 1; [it, n] }
 		end
 

--- a/lib/literal/property.rb
+++ b/lib/literal/property.rb
@@ -10,7 +10,7 @@ class Literal::Property
 
 	include Comparable
 
-	def initialize(name:, type:, kind:, reader:, writer:, predicate:, default:, description:, coercion:)
+	def initialize(name:, type:, kind:, reader:, writer:, predicate:, default:, description:, coercion:, seal: nil)
 		@name = name
 		@type = type
 		@kind = kind
@@ -20,9 +20,10 @@ class Literal::Property
 		@default = default
 		@description = description
 		@coercion = coercion
+		@seal = seal
 	end
 
-	attr_reader :name, :type, :kind, :reader, :writer, :predicate, :default, :description, :coercion
+	attr_reader :name, :type, :kind, :reader, :writer, :predicate, :default, :description, :coercion, :seal
 
 	def optional?
 		default? || @type === nil || undefinable?
@@ -149,6 +150,10 @@ class Literal::Property
 			buffer << "  value = __property__.coerce(value, context: self)\n"
 		end
 
+		if @seal
+			buffer << "  value = __property__.seal.call(value)\n"
+		end
+
 		buffer <<
 			"  __property__.check_writer(self, value)\n" <<
 			"  @" << @name.name << " = value\n" <<
@@ -199,6 +204,10 @@ class Literal::Property
 			generate_initializer_coerce_property(buffer)
 		end
 
+		if @seal
+			generate_initializer_seal_property(buffer)
+		end
+
 		generate_initializer_check_type(buffer)
 		generate_initializer_assign_value(buffer)
 	end
@@ -217,6 +226,14 @@ class Literal::Property
 			"= __property__.coerce(" <<
 			escaped_name <<
 			", context: self)\n"
+	end
+
+	private def generate_initializer_seal_property(buffer = +"")
+		buffer <<
+			escaped_name <<
+			"= __property__.seal.call(" <<
+			escaped_name <<
+			")\n"
 	end
 
 	private def generate_initializer_assign_default(buffer = +"")

--- a/lib/literal/seal.rb
+++ b/lib/literal/seal.rb
@@ -109,6 +109,9 @@ class Literal::Seal
 	end
 
 	def __compose__(first, second)
-		proc { |value| second.call(first.call(value)) }
+		# instance_exec, not call: a composed coercion carried by a seal runs
+		# against the object being constructed, and each stage should see that
+		# context the same way an uncomposed block would.
+		proc { |value| instance_exec(instance_exec(value, &first), &second) }
 	end
 end

--- a/lib/literal/seal.rb
+++ b/lib/literal/seal.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+# A composable property seal. Wraps a callable that fixes a value's final
+# representation — freezing it, for example — running after any coercion and
+# before the type check. Unlike coercions, seals run on every path that
+# stores a value into a real object: the initializer, writers, `from_props`,
+# and `marshal_load`. Drafts drop the seal — their state stays mutable — and
+# it is re-applied when the draft finalizes.
+#
+# Seals must be idempotent and type-preserving.
+#
+# A seal may carry a coercion that runs before it, from compositions like
+# `NilIfEmpty >> Immutable`. Nothing can compose after a seal, and a seal is
+# deliberately not callable — so `Proc#>>` rejects `raw_proc >> seal` at
+# composition time instead of silently demoting the seal to a coercion.
+#
+# Construct with `Literal::Seal(&block)`.
+class Literal::Seal
+	class << self
+		def [](...)
+			new(...)
+		end
+	end
+
+	def initialize(callable = nil, coercion: nil, &block)
+		callable ||= block
+
+		unless callable
+			raise Literal::ArgumentError.new("Literal::Seal requires a callable or a block.")
+		end
+
+		@callable = __proc_from__(callable)
+		@coercion = coercion
+
+		pipeline = self
+		seal = @callable
+
+		@proc = coercion ? proc { |value| seal.call(coercion.call(value)) } : proc { |value| seal.call(value) }
+		@proc.define_singleton_method(:__literal_pipeline__) { pipeline }
+
+		freeze
+	end
+
+	# The full pipeline (coercion, then seal) as a Proc, for property
+	# definitions — `prop :tags, _Array(String), &Immutable` — and for
+	# standalone use like `values.map(&Immutable)`. The returned proc carries
+	# a reference back to this object, so `prop` can split the pipeline into
+	# the property's coercion and seal slots.
+	def to_proc
+		@proc
+	end
+
+	def coercion_proc
+		@coercion
+	end
+
+	def seal_proc
+		@callable
+	end
+
+	def >>(other)
+		other = other.__literal_pipeline__ if other.respond_to?(:__literal_pipeline__)
+
+		case other
+		when Literal::Seal
+			if other.coercion_proc
+				raise Literal::ArgumentError.new(
+					"A coercion cannot run after a seal. Compose as `coercion >> seal` or `seal << coercion` instead.",
+				)
+			end
+
+			Literal::Seal.new(__compose__(@callable, other.seal_proc), coercion: @coercion)
+		else
+			raise Literal::ArgumentError.new(
+				"A coercion cannot run after a seal. Compose as `coercion >> seal` or `seal << coercion` instead.",
+			)
+		end
+	end
+
+	def <<(other)
+		other = other.__literal_pipeline__ if other.respond_to?(:__literal_pipeline__)
+
+		case other
+		when Literal::Seal
+			if @coercion
+				raise Literal::ArgumentError.new(
+					"A coercion cannot run after a seal. Compose as `coercion >> seal` or `seal << coercion` instead.",
+				)
+			end
+
+			Literal::Seal.new(__compose__(other.seal_proc, @callable), coercion: other.coercion_proc)
+		when Literal::Coercion
+			Literal::Seal.new(@callable, coercion: @coercion ? __compose__(other.coercion_proc, @coercion) : other.coercion_proc)
+		else
+			preceding = __proc_from__(other)
+			Literal::Seal.new(@callable, coercion: @coercion ? __compose__(preceding, @coercion) : preceding)
+		end
+	end
+
+	private
+
+	def __proc_from__(callable)
+		case callable
+		when ::Proc
+			callable
+		else
+			callable.respond_to?(:to_proc) ? callable.to_proc : proc { |value| callable.call(value) }
+		end
+	end
+
+	def __compose__(first, second)
+		proc { |value| second.call(first.call(value)) }
+	end
+end

--- a/lib/literal/seal.rb
+++ b/lib/literal/seal.rb
@@ -2,9 +2,12 @@
 
 # A composable property seal. Wraps a callable that fixes a value's final
 # representation — freezing it, for example — running after any coercion and
-# before the type check. Unlike coercions, seals run on every path that
-# stores a value into a real object: the initializer, writers, `from_props`,
-# and `marshal_load`. Drafts drop the seal — their state stays mutable — and
+# before the type check. Unlike coercions, seals run on every constructing
+# path: the initializer, writers, and `from_props` (which takes values that
+# may never have been through construction, and computes defaults itself).
+# They don't run on `marshal_load` — a loaded object was constructed, and
+# sealed, before it was dumped, and the frozen state recorded at dump is
+# what gets restored. Drafts drop the seal — their state stays mutable — and
 # it is re-applied when the draft finalizes.
 #
 # Seals must be idempotent and type-preserving.

--- a/lib/literal/set.rb
+++ b/lib/literal/set.rb
@@ -15,6 +15,7 @@
 class Literal::Set
 	class Generic
 		include Literal::Type
+		include Literal::Coercions::Composable
 
 		def initialize(type)
 			@type = type

--- a/lib/literal/tuple.rb
+++ b/lib/literal/tuple.rb
@@ -13,6 +13,7 @@
 class Literal::Tuple
 	class Generic
 		include Literal::Type
+		include Literal::Coercions::Composable
 
 		def initialize(*types)
 			raise Literal::ArgumentError.new("Literal::Tuple type must have at least one type.") if types.empty?

--- a/lib/literal/types.rb
+++ b/lib/literal/types.rb
@@ -189,6 +189,23 @@ module Literal::Types
 		)
 	end
 
+	# Matches what a slot typed as the given type may hold while drafting: the
+	# type with representation (`_Frozen`) and finality relaxed, so a
+	# `Literal::Properties` class also admits a draft of it.
+	# ```ruby
+	# _DraftState(_Frozen(_Array(String)))
+	# ```
+	def _DraftState(type)
+		DraftStateType.new(type)
+	end
+
+	# Nilable version of `_DraftState`.
+	def _DraftState?(...)
+		_Nilable(
+			_DraftState(...)
+		)
+	end
+
 	#  Matches if the value is an `Enumerable` and all its elements match the given type.
 	# ```ruby
 	# _Enumerable(String)

--- a/lib/literal/types/draft_state_type.rb
+++ b/lib/literal/types/draft_state_type.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# @api private
+#
+# Matches what a slot typed as the given type may hold while drafting — the
+# type with its requirements relaxed: representation (a `_Frozen` constraint
+# doesn't bind draft state) and finality (a slot typed as a
+# `Literal::Properties` class also accepts a draft of it). Finalizing a draft
+# re-imposes both through the drafted type's own construction.
+#
+# The unset sentinel is not included: draft properties compose this with
+# `Literal::Undefined` in a union, where its exact containment marks the
+# property as omittable.
+class Literal::Types::DraftStateType
+	include Literal::Type
+
+	def initialize(type)
+		@type = type
+		@relaxed = __relax__(type)
+		freeze
+	end
+
+	attr_reader :type
+
+	def literal_child_types
+		return enum_for(__method__) unless block_given?
+
+		yield @type
+	end
+
+	def inspect
+		"_DraftState(#{@type.inspect})"
+	end
+
+	def ===(value)
+		@relaxed === value
+	end
+
+	def record_literal_type_errors(ctx)
+		@relaxed.record_literal_type_errors(ctx) if @relaxed.respond_to?(:record_literal_type_errors)
+	end
+
+	def >=(other, context: nil)
+		case other
+		when Literal::Types::DraftStateType
+			Literal.subtype?(other.__relaxed__, @relaxed, context:)
+		else
+			Literal.subtype?(other, @relaxed, context:)
+		end
+	end
+
+	protected def __relaxed__
+		@relaxed
+	end
+
+	private def __relax__(type)
+		case type
+		when Literal::Types::DeferredType
+			# Wrapped rather than materialized: the deferred constant may not
+			# be defined yet when the draft state type is built.
+			Literal::Types::DeferredType.new { __relax__(type.materialize) }
+		when Literal::Types::FrozenType
+			__relax__(type.type)
+		when Literal::Types::NilableType
+			Literal::Types._Nilable(__relax__(type.type))
+		when Literal::Types::UnionType
+			Literal::Types._Union(*type.types.map { |member| __relax__(member) }, *type.primitives)
+		when Literal::Properties
+			# A slot typed as a draft class already holds draft state; only
+			# final types get widened.
+			if Class === type && type <= Literal::Draft
+				type
+			else
+				Literal::Types._Union(type, Literal::Draft::Type.new(type))
+			end
+		else
+			type
+		end
+	end
+
+	freeze
+end

--- a/test/coercion.test.rb
+++ b/test/coercion.test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+test "coercions compose in both directions" do
+	a = Literal::Coercion { |it| it + [:a] }
+	b = Literal::Coercion { |it| it + [:b] }
+
+	assert Literal::Coercion === (a >> b)
+	assert_equal (a >> b).call([]), [:a, :b]
+	assert_equal (a << b).call([]), [:b, :a]
+	assert_equal (a >> proc { |it| it + [:p] }).call([]), [:a, :p]
+end
+
+test "composing a coercion into a seal returns a seal whose coercion runs first" do
+	strip = Literal::Coercion { |it| it.strip }
+
+	assert Literal::Seal === (strip >> Literal::Coercions::Immutable)
+	assert Literal::Seal === (Literal::Coercions::Immutable << strip)
+end
+
+test "a coercion can never come after a seal" do
+	seal = Literal::Seal { |it| it.frozen? ? it : it.dup.freeze }
+	coercion = Literal::Coercion { |it| it }
+
+	assert_raises(Literal::ArgumentError) { seal >> coercion }
+	assert_raises(Literal::ArgumentError) { seal >> proc { |it| it } }
+	assert_raises(Literal::ArgumentError) { coercion << seal }
+	assert_raises(Literal::ArgumentError) { seal >> (coercion >> Literal::Coercions::Immutable) }
+	assert_raises(Literal::ArgumentError) { (coercion >> Literal::Coercions::Immutable) << seal }
+end
+
+test "seals are not callable, so Proc#>> rejects them at composition time" do
+	assert_raises(TypeError) { proc { |it| it } >> Literal::Coercions::Immutable }
+end
+
+class CoercionSealSplit < Literal::Struct
+	prop :name, String, reader: :public, &(
+		Literal::Coercion { |it| it.strip } >> Literal::Coercions::Immutable
+	)
+end
+
+test "a composed pipeline splits into the property's coercion and seal slots" do
+	property = CoercionSealSplit.literal_properties[:name]
+
+	assert property.coercion
+	assert property.seal
+
+	constructed = CoercionSealSplit.new(name: " Joel ")
+
+	assert_equal constructed.name, "Joel"
+	assert constructed.name.frozen?
+
+	# from_props is a final-value path: the seal applies, the coercion doesn't.
+	restored = CoercionSealSplit.from_props(name: " Joel ")
+
+	assert_equal restored.name, " Joel "
+	assert restored.name.frozen?
+end
+
+class CoercionContext < Literal::Struct
+	prop :plain, String, reader: :public do |value|
+		tag(value)
+	end
+
+	prop :composed, String, reader: :public, &(
+		Literal::Coercion { |it| tag(it) } >> proc { |it| tag(it) }
+	)
+
+	prop :sealed, String, reader: :public, &(
+		(Literal::Coercions::Immutable << proc { |it| tag(it) }) << proc { |it| tag(it) }
+	)
+
+	private def tag(value)
+		"#{value}!"
+	end
+end
+
+test "composed coercion stages see the instance context like an uncomposed block" do
+	object = CoercionContext.new(plain: "a", composed: "b", sealed: "c")
+
+	assert_equal object.plain, "a!"
+	assert_equal object.composed, "b!!"
+	assert_equal object.sealed, "c!!"
+	assert object.sealed.frozen?
+end

--- a/test/draft.test.rb
+++ b/test/draft.test.rb
@@ -296,3 +296,24 @@ test "drafting relaxes deferred types without materializing them" do
 
 	assert_equal draft.finalize.name, "a"
 end
+
+test "Literal::Draft returns the canonical draft class for the class's current shape" do
+	klass = Class.new(Literal::Data) { prop :a, String }
+
+	first = Literal::Draft(klass)
+
+	assert first.equal?(Literal::Draft(klass))
+
+	klass.class_eval { prop :b, _Nilable(Integer), default: nil }
+	second = Literal::Draft(klass)
+
+	refute first.equal?(second)
+	assert second.new.respond_to?(:b)
+
+	# A subclass with the same properties still drafts into itself.
+	subclass = Class.new(klass)
+
+	refute Literal::Draft(subclass).equal?(second)
+	assert_equal Literal::Draft(subclass).__type__, subclass
+end
+

--- a/test/draft.test.rb
+++ b/test/draft.test.rb
@@ -317,3 +317,67 @@ test "Literal::Draft returns the canonical draft class for the class's current s
 	assert_equal Literal::Draft(subclass).__type__, subclass
 end
 
+test "build constructs, yields and finalizes a draft in one call" do
+	condition = true
+
+	value = Literal::Draft(DraftExample).build(id: 1) do |draft|
+		draft.name = "John" if condition
+	end
+
+	assert DraftExample === value
+	assert_equal value.name, "John"
+	assert_equal value.age, 18
+end
+
+test "finalize yields the draft to a block before building" do
+	condition = true
+
+	value = Literal::Draft(DraftExample).new(id: 1).finalize do |draft|
+		draft.name = "John" if condition
+	end
+
+	assert DraftExample === value
+	assert_equal value.name, "John"
+	assert_equal value.age, 18
+end
+
+test "finalize assigns props before yielding" do
+	Literal::Draft(DraftExample).new(name: "John").finalize(id: 1) do |draft|
+		assert_equal draft.id, 1
+	end
+end
+
+test "Literal::Data.build builds through a draft" do
+	value = DraftExample.build do |draft|
+		draft.name = "John"
+		draft.id = 1
+	end
+
+	assert_equal value, DraftExample.new(name: "John", id: 1)
+end
+
+test "Literal::Data.build passes arguments to the draft's constructor" do
+	condition = false
+
+	value = DraftExample.build(name: "John", id: 1) do |draft|
+		draft.nickname = "Johnny" if condition
+	end
+
+	assert_equal value, DraftExample.new(name: "John", id: 1)
+	assert_equal DraftExample.build(name: "John", id: 1), value
+end
+
+test "Literal::Struct.build builds through a draft" do
+	klass = Class.new(Literal::Struct) do
+		prop :name, String, reader: :public
+		prop :id, Integer, reader: :public
+	end
+
+	value = klass.build(id: 1) do |draft|
+		draft.name = "John"
+	end
+
+	assert klass === value
+	assert_equal value.name, "John"
+	assert_equal value.id, 1
+end

--- a/test/draft.test.rb
+++ b/test/draft.test.rb
@@ -168,3 +168,108 @@ test "drafts keep positional properties positional" do
 
 	assert_equal draft.finalize, klass.new(1, 2)
 end
+
+class DraftNestedAddress < Literal::Data
+	prop :street, String
+	prop :city, String, default: "London"
+end
+
+class DraftNestedPerson < Literal::Data
+	prop :name, String
+	prop :address, DraftNestedAddress
+	prop :fallback_address, _Nilable(DraftNestedAddress), default: nil
+end
+
+test "draft slots accept a draft of the property's type" do
+	person = Literal::Draft(DraftNestedPerson).new
+	address = Literal::Draft(DraftNestedAddress).new
+
+	person.address = address
+
+	assert person.address.equal?(address)
+	assert_raises(Literal::TypeError) { person.address = "not an address" }
+end
+
+test "draft slots accept drafts of subtypes of the property's type" do
+	child = Class.new(DraftNestedAddress)
+	person = Literal::Draft(DraftNestedPerson).new
+
+	person.address = Literal::Draft(child).new(street: "1 Main St")
+
+	assert_equal person.address.street, "1 Main St"
+end
+
+test "nested drafts are accepted through nilable types" do
+	person = Literal::Draft(DraftNestedPerson).new
+
+	person.fallback_address = Literal::Draft(DraftNestedAddress).new(street: "2 Side St")
+
+	assert_equal person.fallback_address.street, "2 Side St"
+end
+
+test "finalize builds nested drafts too, applying their defaults" do
+	person_draft = Literal::Draft(DraftNestedPerson).new(name: "Joel")
+	person_draft.address = Literal::Draft(DraftNestedAddress).new(street: "1 Main St")
+
+	person = person_draft.finalize
+
+	assert DraftNestedPerson === person
+	assert_equal person.address, DraftNestedAddress.new(street: "1 Main St")
+	assert_equal person.address.city, "London"
+end
+
+test "finalize raises when a nested draft is missing required properties" do
+	person_draft = Literal::Draft(DraftNestedPerson).new(name: "Joel")
+	person_draft.address = Literal::Draft(DraftNestedAddress).new
+
+	error = assert_raises(Literal::ArgumentError) { person_draft.finalize }
+
+	assert error.message.include?("Missing property :street")
+end
+
+test "finalize doesn't mutate the draft" do
+	person_draft = Literal::Draft(DraftNestedPerson).new(name: "Joel")
+	address_draft = Literal::Draft(DraftNestedAddress).new(street: "1 Main St")
+	person_draft.address = address_draft
+
+	first = person_draft.finalize
+	second = person_draft.finalize
+
+	assert person_draft.address.equal?(address_draft)
+	assert_equal first, second
+	refute first.address.equal?(second.address)
+end
+
+class DraftPendingHolder < Literal::Data
+	prop :pending, Literal::Draft(DraftNestedAddress)
+end
+
+test "a property typed as a draft class keeps its draft at finalize" do
+	holder_draft = Literal::Draft(DraftPendingHolder).new
+	pending = Literal::Draft(DraftNestedAddress).new(street: "1 Main St")
+	holder_draft.pending = pending
+
+	holder = holder_draft.finalize
+
+	assert holder.pending.equal?(pending)
+end
+
+test "draft coercions skip nested drafts" do
+	klass = Class.new(Literal::Struct) do
+		prop :address, DraftNestedAddress, reader: :public do |value|
+			(Hash === value) ? DraftNestedAddress.new(**value) : value
+		end
+	end
+
+	draft = Literal::Draft(klass).new
+
+	draft.address = { street: "1 Main St" }
+
+	assert DraftNestedAddress === draft.address
+
+	nested = Literal::Draft(DraftNestedAddress).new(street: "2 Side St")
+	draft.address = nested
+
+	assert draft.address.equal?(nested)
+	assert_equal draft.finalize.address.street, "2 Side St"
+end

--- a/test/draft.test.rb
+++ b/test/draft.test.rb
@@ -273,3 +273,26 @@ test "draft coercions skip nested drafts" do
 	assert draft.address.equal?(nested)
 	assert_equal draft.finalize.address.street, "2 Side St"
 end
+
+class DraftDeferredNode < Literal::Data
+	prop :name, String
+	prop :child, _Nilable(_Deferred { DraftDeferredNode }), default: nil
+end
+
+test "deferred property types accept nested drafts" do
+	root = Literal::Draft(DraftDeferredNode).new(name: "root")
+	root.child = Literal::Draft(DraftDeferredNode).new(name: "leaf")
+
+	assert_equal root.finalize.child.name, "leaf"
+end
+
+test "drafting relaxes deferred types without materializing them" do
+	klass = Class.new(Literal::Data) do
+		prop :name, String
+		prop :other, _Nilable(_Deferred { NeverDefinedAnywhere }), default: nil
+	end
+
+	draft = Literal::Draft(klass).new(name: "a")
+
+	assert_equal draft.finalize.name, "a"
+end

--- a/test/struct.test.rb
+++ b/test/struct.test.rb
@@ -205,3 +205,25 @@ test do
 	with_keyword_property_names.end = "finish2"
 	assert_equal(with_keyword_property_names.to_h, { :begin => "start2", :end => "finish2", :module => nil })
 end
+
+class ::RootStructWithSealedProp < Literal::Struct
+	SEAL_CALLS = []
+
+	prop :tags, _Array(String), &(Literal::Seal { |it|
+		SEAL_CALLS << it
+		it.frozen? ? it : it.dup.freeze
+	})
+end
+
+test "seals run at construction but not when marshal loading" do
+	a = RootStructWithSealedProp.new(tags: ["a"])
+
+	assert a.tags.frozen?
+
+	calls_before = RootStructWithSealedProp::SEAL_CALLS.size
+	b = Marshal.load(Marshal.dump(a))
+
+	assert_equal RootStructWithSealedProp::SEAL_CALLS.size, calls_before
+	assert b.tags.frozen?
+	assert_equal b, a
+end

--- a/test/struct.test.rb
+++ b/test/struct.test.rb
@@ -124,6 +124,27 @@ test "marshalling a frozen struct" do
 	assert b.frozen?
 end
 
+class ::RootStructWithFrozenProp < Literal::Struct
+	prop :tags, _Frozen(_Array(String))
+	prop :list, _Array(String)
+end
+
+test "marshalling restores the frozen state of property values" do
+	a = RootStructWithFrozenProp.new(tags: ["a"].freeze, list: ["b"])
+
+	b = Marshal.load(Marshal.dump(a))
+
+	assert_equal b, a
+	assert b.tags.frozen?
+	refute b.list.frozen?
+end
+
+test "marshalling loads version 1 payloads" do
+	a = RootStruct.from_pack([1, { name: "Joel" }, false])
+
+	assert_equal a.name, "Joel"
+end
+
 test "as_pack/from_pack" do
 	a = RootStruct.new(name: "Joel")
 	a.freeze

--- a/test/types/_draft_state.test.rb
+++ b/test/types/_draft_state.test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+include Literal::Types
+
+class DraftStateAddress < Literal::Data
+	prop :street, String
+end
+
+test "matches the type itself" do
+	assert _DraftState(String) === "a"
+	refute _DraftState(String) === 1
+	assert _DraftState(DraftStateAddress) === DraftStateAddress.new(street: "1 Main St")
+end
+
+test "relaxes frozen constraints" do
+	type = _DraftState(_Frozen(_Array(String)))
+
+	assert type === ["a"]
+	assert type === ["a"].freeze
+	refute type === [1]
+end
+
+test "admits drafts of Literal::Properties classes, including subtypes" do
+	type = _DraftState(DraftStateAddress)
+
+	assert type === Literal::Draft(DraftStateAddress).new
+	assert type === Literal::Draft(Class.new(DraftStateAddress)).new
+	refute type === Literal::Draft(Class.new(Literal::Data)).new
+end
+
+test "relaxes through nilable and union types" do
+	assert _DraftState(_Nilable(DraftStateAddress)) === Literal::Draft(DraftStateAddress).new
+	assert _DraftState(_Nilable(DraftStateAddress)) === nil
+	assert _DraftState(_Union(Integer, _Frozen(DraftStateAddress))) === Literal::Draft(DraftStateAddress).new
+	assert _DraftState(_Union(Integer, _Frozen(DraftStateAddress))) === 1
+end
+
+test "defers deferred types instead of materializing them" do
+	type = _DraftState(_Deferred { DraftStateNotYetDefined })
+
+	Object.const_set(:DraftStateNotYetDefined, Class.new(Literal::Data) { prop :x, Integer })
+
+	assert type === DraftStateNotYetDefined.new(x: 1)
+	assert type === Literal::Draft(DraftStateNotYetDefined).new
+end
+
+test "does not widen slots typed as draft classes" do
+	type = _DraftState(Literal::Draft(DraftStateAddress))
+
+	assert type === Literal::Draft(DraftStateAddress).new
+	refute type === DraftStateAddress.new(street: "1 Main St")
+end
+
+test "does not include the unset sentinel" do
+	refute _DraftState(DraftStateAddress) === Literal::Undefined
+end
+
+test "subtyping delegates to the relaxed type" do
+	assert_subtype _DraftState(String), _DraftState(String)
+	assert_subtype String, _DraftState(_Frozen(String))
+	assert_subtype Literal::Draft(DraftStateAddress), _DraftState(DraftStateAddress)
+	refute_subtype Integer, _DraftState(String)
+end
+
+test "inspects as _DraftState" do
+	assert_equal _DraftState(String).inspect, "_DraftState(String)"
+end


### PR DESCRIPTION
## What this does

Three related changes, one commit each:

### `Literal::Coercion` and `Literal::Seal`

Splits the property pipeline into two explicit stages:

- **Coercions** normalize input before the type check. They run only at input boundaries — the initializer, writers, and draft assignment — never on final-value paths like `from_props` or `marshal_load`.
- **Seals** fix a value's final representation (freezing it, for example), running after any coercion and before the type check, on every *constructing* path — the initializer, writers, and `from_props`, which takes values that may never have been through construction and computes defaults itself. They don't run on `marshal_load`: a loaded object was constructed (and sealed) before it was dumped, and the frozen state recorded at dump is what gets restored. Seals must be idempotent and type-preserving.

Both compose with `>>` and `<<`. Composing two coercions yields a coercion; composing a coercion into a seal yields a seal whose coercion runs first. Any arrangement that would run a coercion *after* a seal is rejected at composition time — and `Seal` is deliberately not callable, so `raw_proc >> seal` fails immediately instead of silently demoting the seal.

Properties take either through the existing block slot — the proc built by `Literal::Coercion()` / `Literal::Seal()` carries its pipeline structure, and `prop` splits it into the property's coercion and seal. Collection generics compose too: `Literal::Array(String) >> Immutable`.

The built-in `Immutable` and `DeepImmutable` become seals; `NilIfEmpty` becomes an explicit coercion.

### Frozen state through Marshal

`Marshal.load` rebuilds contained objects unfrozen, so a property value that was frozen when dumped (a `_Frozen`-typed value, for example) came back mutable and failed the load-time type check. `marshal_dump` now records which values were frozen (payload version 2) and `marshal_load` re-freezes them before checking. Version 1 payloads still load, and old readers ignore the new payload element.

### Nested drafts

A draft slot typed as a `Literal::Properties` class now also accepts a draft of that type (or a subtype), and `finalize` builds nested drafts depth-first — unless the drafted type's property wanted a draft as-is, in which case it stays one. Finalize never mutates the draft: finalizing twice builds two independent values.

Under the hood, relaxation is a first-class type: `_DraftState(T)` matches what a slot typed `T` may hold while drafting — one walk that relaxes both representation (stripping `_Frozen`) and finality (widening `T` to accept drafts of `T`). Draft properties are `_Union(Undefined, _DraftState(T))`, so errors and introspection name what a draft slot actually accepts. The union member is `Literal::Draft::Type`, a lightweight matcher with `Literal::Draft(T)`'s `===` semantics but no generated class, so recursive types (a `Person` with a `Person` property) don't recurse forever at draft-class definition. Draft coercions skip nested drafts the way they skip `Undefined` — a draft isn't the drafted type's input yet; it meets the coercion's output contract at finalize through its own construction.

**Deliberately out of scope:** drafts inside collections (`_Array(T)`, `Literal::Array(T)`). Widening element types would force a type-driven relax/restore pair over the whole type algebra; holding that until there's a real need.

## Testing

Each commit is individually green against the full suite (3172 → 3172 → 3176 → 3192 tests). New tests cover marshalling frozen-state round-trips, version 1 payload compatibility, and nested drafts: slot acceptance (subtypes, through `_Nilable`), depth-first finalize with nested defaults, inner missing-property errors, purity, draft-typed slots keeping their drafts, and coercion passthrough. Known gap: the `>>`/`<<` composition error paths have no direct tests yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Canonical draft classes

`Literal::Draft(Foo)` now returns the same generated class on every call until `Foo`'s properties change, instead of a fresh class per call. The cache is keyed by the class's schema in an `ObjectSpace::WeakKeyMap`, with each entry recording the schema's sorted-properties snapshot — an array the schema replaces on every mutation, so its identity changes exactly when the schema does. Reopening a class invalidates lazily with no mutation tracking, and anonymous classes (and their stale drafts) stay collectable.

### Building through drafts

`Draft#finalize` takes an optional block, yielded the draft after any props are assigned and before the value is built — for last touches like conditional assignment. Draft classes gain `build` — construct, yield, finalize in one call, with arguments going to the constructor and the block to `finalize` — and `Literal::DataStructure.build` layers the same onto Data and Struct themselves (structs are mutable, but required properties still make incremental construction impossible without a draft):

```ruby
Foo.build(id: 1) do |draft|
  draft.name = name if bar?
end
```

Review follow-ups from the Codex findings are also in: deferred property types relax lazily (and the draft union now puts `Undefined` first so unresolved forward references never materialize early), and composed coercion stages run in the property context via `instance_exec`, with the composition algebra now under direct test.
